### PR TITLE
feat: allow empty include list for include-all mode

### DIFF
--- a/src/rhiza/commands/validate.py
+++ b/src/rhiza/commands/validate.py
@@ -128,6 +128,9 @@ def _parse_yaml_file(template_file: Path) -> tuple[bool, dict | None]:
 def _validate_required_fields(config: dict) -> bool:
     """Validate required fields exist and have correct types.
 
+    The 'include' field is optional - if omitted or empty, all files from
+    the template repository will be included (subject to exclude filters).
+
     Args:
         config: Configuration dictionary.
 
@@ -135,9 +138,10 @@ def _validate_required_fields(config: dict) -> bool:
         True if all validations pass, False otherwise.
     """
     logger.debug("Validating required fields")
+    # Only template-repository is truly required
+    # include is optional (empty means include all)
     required_fields = {
         "template-repository": str,
-        "include": list,
     }
 
     validation_passed = True
@@ -189,6 +193,9 @@ def _validate_repository_format(config: dict) -> bool:
 def _validate_include_paths(config: dict) -> bool:
     """Validate include paths.
 
+    An empty or missing include list is valid and means "include all files"
+    from the template repository (subject to exclude filters).
+
     Args:
         config: Configuration dictionary.
 
@@ -197,6 +204,7 @@ def _validate_include_paths(config: dict) -> bool:
     """
     logger.debug("Validating include paths")
     if "include" not in config:
+        logger.success("include not specified - will include all files from template repository")
         return True
 
     include = config["include"]
@@ -205,9 +213,8 @@ def _validate_include_paths(config: dict) -> bool:
         logger.error("Example: include: ['.github', '.gitignore']")
         return False
     elif len(include) == 0:
-        logger.error("include list cannot be empty")
-        logger.error("Add at least one path to materialize")
-        return False
+        logger.success("include list is empty - will include all files from template repository")
+        return True
     else:
         logger.success(f"include list has {len(include)} path(s)")
         for path in include:

--- a/src/rhiza/models.py
+++ b/src/rhiza/models.py
@@ -23,6 +23,7 @@ class RhizaTemplate:
         template_host: The git hosting platform ("github" or "gitlab").
             Defaults to "github" if not specified in the template file.
         include: List of paths to include from the template repository.
+            If empty and exclude is provided, all files will be included except those in exclude.
         exclude: List of paths to exclude from the template repository (default: empty list).
     """
 
@@ -31,6 +32,18 @@ class RhizaTemplate:
     template_host: str = "github"
     include: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
+
+    @property
+    def include_all(self) -> bool:
+        """Check if this template should include all files from the repository.
+
+        Returns True when include list is empty, meaning all files should be
+        included (subject to exclude filters).
+
+        Returns:
+            True if all files should be included, False if specific paths are listed.
+        """
+        return len(self.include) == 0
 
     @classmethod
     def from_yaml(cls, file_path: Path) -> "RhizaTemplate":
@@ -85,8 +98,9 @@ class RhizaTemplate:
         if self.template_host and self.template_host != "github":
             config["template-host"] = self.template_host
 
-        # Include is always present as it's a required field for the config to be useful
-        config["include"] = self.include
+        # Only include 'include' if it's not empty (empty means include-all mode)
+        if self.include:
+            config["include"] = self.include
 
         # Only include exclude if it's not empty
         if self.exclude:

--- a/tests/test_commands/test_validate.py
+++ b/tests/test_commands/test_validate.py
@@ -123,8 +123,8 @@ class TestValidateCommand:
         result = validate(tmp_path)
         assert result is False
 
-    def test_validate_fails_on_empty_include_list(self, tmp_path):
-        """Test that validate fails when include list is empty."""
+    def test_validate_succeeds_on_empty_include_list(self, tmp_path):
+        """Test that validate succeeds when include list is empty (include-all mode)."""
         # Setup git repo
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
@@ -133,7 +133,7 @@ class TestValidateCommand:
         pyproject_file = tmp_path / "pyproject.toml"
         pyproject_file.write_text("[project]\nname = 'test'\n")
 
-        # Create template with empty include
+        # Create template with empty include (include-all mode)
         rhiza_dir = tmp_path / ".rhiza"
         rhiza_dir.mkdir(parents=True)
         template_file = rhiza_dir / "template.yml"
@@ -148,7 +148,60 @@ class TestValidateCommand:
             )
 
         result = validate(tmp_path)
-        assert result is False
+        assert result is True
+
+    def test_validate_succeeds_on_missing_include_list(self, tmp_path):
+        """Test that validate succeeds when include is not specified (include-all mode)."""
+        # Setup git repo
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        # Create pyproject.toml
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text("[project]\nname = 'test'\n")
+
+        # Create template without include field
+        rhiza_dir = tmp_path / ".rhiza"
+        rhiza_dir.mkdir(parents=True)
+        template_file = rhiza_dir / "template.yml"
+
+        with open(template_file, "w") as f:
+            yaml.dump(
+                {
+                    "template-repository": "owner/repo",
+                },
+                f,
+            )
+
+        result = validate(tmp_path)
+        assert result is True
+
+    def test_validate_succeeds_with_only_exclude(self, tmp_path):
+        """Test that validate succeeds with only exclude list (include-all mode)."""
+        # Setup git repo
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        # Create pyproject.toml
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text("[project]\nname = 'test'\n")
+
+        # Create template with only exclude (no include = include all)
+        rhiza_dir = tmp_path / ".rhiza"
+        rhiza_dir.mkdir(parents=True)
+        template_file = rhiza_dir / "template.yml"
+
+        with open(template_file, "w") as f:
+            yaml.dump(
+                {
+                    "template-repository": "owner/repo",
+                    "exclude": [".github/CODEOWNERS", ".github/workflows/deploy.yml"],
+                },
+                f,
+            )
+
+        result = validate(tmp_path)
+        assert result is True
 
     def test_validate_succeeds_on_valid_template(self, tmp_path):
         """Test that validate succeeds on a valid template.yml."""


### PR DESCRIPTION
- Add include_all property to RhizaTemplate model
- Make include field optional in validation (empty = include all files)
- Update materialize to do full clone instead of sparse checkout for include-all
- Exclude .git directory automatically in include-all mode
- Add comprehensive tests for include-all feature in models, validate, and materialize