### PR TITLE
Template exclude by default

### DIFF
--- a/src/rhiza/commands/materialize.py
+++ b/src/rhiza/commands/materialize.py
@@ -253,9 +253,16 @@ def _copy_files_to_target(
     excluded_files = {f.resolve() for f in __expand_paths(tmp_dir, excluded_paths)}
 
     # Always exclude .rhiza/template.yml to prevent overwriting local configuration
-    template_config = (tmp_dir / ".rhiza" / "template.yml").resolve()
+    # Also exclude .rhiza/history to prevent overwriting local history with template history
+    rhiza_dir = tmp_dir / ".rhiza"
+    template_config = (rhiza_dir / "template.yml").resolve()
+    upstream_history = (rhiza_dir / "history").resolve()
+
     if template_config.is_file():
         excluded_files.add(template_config)
+
+    if upstream_history.is_file():
+        excluded_files.add(upstream_history)
 
     if excluded_files:
         logger.info(f"Excluding {len(excluded_files)} file(s) based on exclude patterns")
@@ -342,9 +349,17 @@ def _clean_orphaned_files(target: Path, materialized_files: list[Path]) -> None:
     currently_materialized_files = set(materialized_files)
     orphaned_files = previously_tracked_files - currently_materialized_files
 
+    # Protected files that should never be deleted automatically
+    # even if they are orphaned (e.g. user chose to stop tracking them)
+    protected_files = {Path(".rhiza/template.yml")}
+
     if orphaned_files:
         logger.info(f"Found {len(orphaned_files)} orphaned file(s) no longer maintained by template")
         for file_path in sorted(orphaned_files):
+            if file_path in protected_files:
+                logger.info(f"Skipping protected file: {file_path}")
+                continue
+
             full_path = target / file_path
             if full_path.exists():
                 try:


### PR DESCRIPTION
This pull request enhances the safety and reliability of the materialization process in the `rhiza` project by ensuring critical configuration and history files are protected from accidental overwrites or deletions. It also introduces comprehensive tests to verify these protections and correct behavior when using custom template branches.

**Protections for configuration and history files:**

* Updated `_copy_files_to_target` in `materialize.py` to always exclude `.rhiza/template.yml` and `.rhiza/history` from being copied from the template repository, preventing overwriting of local configuration and history.
* Modified `_clean_orphaned_files` to ensure `.rhiza/template.yml` is never deleted automatically, even if it is considered orphaned, protecting user configuration.

**Expanded test coverage for materialization logic:**

* Added tests to verify that materialization works with custom template branches and that the local `.rhiza/template.yml` is preserved when `force=True`, ensuring user configuration is not overwritten by the template repository.
* Added tests to confirm `.rhiza/history` from the template is ignored during copy, preventing upstream history from overwriting local history.
* Added tests to verify `.rhiza/template.yml` is not deleted even if it becomes orphaned, maintaining user configuration integrity.