### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -9,7 +9,6 @@ templates:
 - legal
 - tests
 - book
-- renovate
 files:
 - .bandit
 - .editorconfig
@@ -91,7 +90,6 @@ files:
 - docs/index.md
 - docs/mkdocs-base.yml
 - pytest.ini
-- renovate.json
 - ruff.toml
-synced_at: '2026-04-25T03:59:15Z'
+synced_at: '2026-05-18T00:45:20Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@v0.10.3`
- Last sync: 2026-05-18T00:45:20Z
- Sync date: 2026-05-18T00:45:22.455373+00:00