### PR TITLE
feat: add path remapping support for bundle file entries

### DIFF
--- a/src/rhiza/commands/sync.py
+++ b/src/rhiza/commands/sync.py
@@ -110,7 +110,7 @@ def _clone_template(
     template: RhizaTemplate,
     git_ctx: GitContext,
     branch: str = "main",
-) -> tuple[Path, str, list[str]]:
+) -> tuple[Path, str, list[str], dict[str, str]]:
     """Clone the upstream template repository and resolve include paths.
 
     Clones the template repository using sparse checkout.  When
@@ -124,9 +124,10 @@ def _clone_template(
             on the template.
 
     Returns:
-        Tuple of ``(upstream_dir, upstream_sha, resolved_include)`` where
+        Tuple of ``(upstream_dir, upstream_sha, resolved_include, path_map)`` where
         *upstream_dir* is a temporary directory containing the cloned repository
-        tree.  The caller is responsible for removing *upstream_dir* when done.
+        tree and *path_map* maps source paths to destination paths for remapped
+        entries.  The caller is responsible for removing *upstream_dir* when done.
 
     Raises:
         ValueError: If ``template_repository`` is not set, the host is
@@ -176,17 +177,19 @@ def _clone_template(
             all_bundle_names = template.templates
 
         resolved_paths = bundles.resolve_to_paths(all_bundle_names)
+        path_map = bundles.resolve_to_path_map(all_bundle_names)
         # Merge resolved bundle paths with any explicit include: paths (hybrid mode)
         merged_paths = list(dict.fromkeys(resolved_paths + include_paths))
         git_ctx.update_sparse_checkout(upstream_dir, merged_paths)
         include_paths = merged_paths
     else:
+        path_map = {}
         git_ctx.clone_repository(template.git_url, upstream_dir, rhiza_branch, include_paths)
 
     upstream_sha = git_ctx.get_head_sha(upstream_dir)
     logger.info(f"Upstream HEAD: {upstream_sha[:12]}")
 
-    return upstream_dir, upstream_sha, include_paths
+    return upstream_dir, upstream_sha, include_paths, path_map
 
 
 def sync(
@@ -230,7 +233,7 @@ def sync(
     original_include = list(template.include)
 
     logger.info(f"Cloning {template.template_repository}@{template.template_branch} (upstream)")
-    upstream_dir, upstream_sha, resolved_include = _clone_template(template, git_ctx, branch=branch)
+    upstream_dir, upstream_sha, resolved_include, path_map = _clone_template(template, git_ctx, branch=branch)
 
     # Synchronizes target with upstream template snapshot transactionally; cleans up resources
     try:
@@ -240,7 +243,9 @@ def sync(
         upstream_snapshot = Path(tempfile.mkdtemp())
         try:
             excludes = _excluded_set(upstream_dir, template.exclude)
-            materialized = _prepare_snapshot(upstream_dir, resolved_include, excludes, upstream_snapshot)
+            materialized = _prepare_snapshot(
+                upstream_dir, resolved_include, excludes, upstream_snapshot, path_map=path_map
+            )
             logger.info(f"Upstream: {len(materialized)} file(s) to consider")
             lock = TemplateLock(
                 sha=upstream_sha,
@@ -275,6 +280,7 @@ def sync(
                     excludes=excludes,
                     lock=lock,
                     lock_file=lock_file,
+                    path_map=path_map,
                 )
                 if not clean:
                     logger.error("Sync completed with conflicts — see the file list above for details")

--- a/src/rhiza/models/_git_utils.py
+++ b/src/rhiza/models/_git_utils.py
@@ -478,6 +478,7 @@ class GitContext:
         excludes: set[str],
         lock: "TemplateLock",
         lock_file: "Path | None" = None,
+        path_map: "dict[str, str] | None" = None,
     ) -> bool:
         """Execute the merge strategy (cruft-style 3-way merge).
 
@@ -496,6 +497,8 @@ class GitContext:
             lock: Pre-built :class:`~rhiza.models.TemplateLock` for this sync.
             lock_file: Optional explicit path for the lock file.  When ``None``
                 the default ``<target>/.rhiza/template.lock`` is used.
+            path_map: Optional source→destination path mapping for remapped
+                bundle file entries.
 
         Returns:
             True if all changes applied cleanly, False if any conflicts remain.
@@ -527,6 +530,7 @@ class GitContext:
                     excludes,
                     lock,
                     lock_file=lock_file,
+                    path_map=path_map,
                 )
             else:
                 logger.info("First sync — copying all template files")
@@ -776,6 +780,7 @@ class GitContext:
         excludes: set[str],
         lock: "TemplateLock",
         lock_file: "Path | None" = None,
+        path_map: "dict[str, str] | None" = None,
     ) -> bool:
         """Compute and apply the diff between base and upstream snapshots.
 
@@ -790,6 +795,8 @@ class GitContext:
             lock: Pre-built :class:`~rhiza.models.TemplateLock` for this sync.
             lock_file: Optional explicit path for the lock file.  When ``None``
                 the default ``<target>/.rhiza/template.lock`` is used.
+            path_map: Optional source→destination path mapping for remapped
+                bundle file entries.
 
         Returns:
             True if all changes applied cleanly, False if any conflicts remain.
@@ -800,7 +807,7 @@ class GitContext:
         base_clone = Path(tempfile.mkdtemp())
         try:
             self.clone_at_sha(template.git_url, base_sha, base_clone, template.include)
-            _prepare_snapshot(base_clone, template.include, excludes, base_snapshot)
+            _prepare_snapshot(base_clone, template.include, excludes, base_snapshot, path_map=path_map)
         except Exception:
             logger.warning("Could not checkout base commit — treating all files as new")
         finally:
@@ -936,29 +943,62 @@ def _excluded_set(base_dir: Path, excluded_paths: list[str]) -> set[str]:
     return result
 
 
+def _remap_path(source: str, path_map: dict[str, str]) -> str:
+    """Translate *source* to its destination path using *path_map*.
+
+    Supports both exact file matches and directory-prefix matches.  A prefix
+    match is triggered when a key ends with ``/`` or when *source* starts with
+    ``<key>/``.
+
+    Args:
+        source: Source-relative path from the template clone.
+        path_map: Mapping of source path → destination path.
+
+    Returns:
+        The destination path, or *source* unchanged when no mapping applies.
+    """
+    if source in path_map:
+        return path_map[source]
+    for src, dest in path_map.items():
+        src_prefix = src.rstrip("/") + "/"
+        if source.startswith(src_prefix):
+            dest_prefix = dest.rstrip("/") + "/"
+            return dest_prefix + source[len(src_prefix) :]
+    return source
+
+
 def _prepare_snapshot(
     clone_dir: Path,
     include_paths: list[str],
     excludes: set[str],
     snapshot_dir: Path,
+    path_map: dict[str, str] | None = None,
 ) -> list[Path]:
     """Copy included (non-excluded) files from a clone into a snapshot directory.
 
+    When *path_map* is provided, files are written at their destination paths
+    (rather than their source paths) so that downstream diffs and merges operate
+    on the correct target locations.
+
     Args:
         clone_dir: Root of the template clone.
-        include_paths: Paths to include.
-        excludes: Set of relative paths to exclude.
+        include_paths: Source paths to include.
+        excludes: Set of relative source paths to exclude.
         snapshot_dir: Destination directory for the snapshot.
+        path_map: Optional source→destination path mapping.  Keys may be exact
+            file paths or directory prefixes.
 
     Returns:
-        List of relative file paths that were copied.
+        List of relative destination file paths that were copied.
     """
+    effective_map = path_map or {}
     materialized: list[Path] = []
     for f in _expand_paths(clone_dir, include_paths):
-        rel = str(f.relative_to(clone_dir))
-        if rel not in excludes:
-            dst = snapshot_dir / rel
+        rel_source = str(f.relative_to(clone_dir))
+        if rel_source not in excludes:
+            rel_dest = _remap_path(rel_source, effective_map)
+            dst = snapshot_dir / rel_dest
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(f, dst)
-            materialized.append(Path(rel))
+            materialized.append(Path(rel_dest))
     return materialized

--- a/src/rhiza/models/bundle.py
+++ b/src/rhiza/models/bundle.py
@@ -7,6 +7,77 @@ from rhiza.models._base import YamlSerializable
 from rhiza.models._git_utils import _normalize_to_list
 
 
+@dataclass(frozen=True)
+class BundleFileEntry:
+    """A file entry in a bundle, with optional source→destination path remapping.
+
+    When ``source`` and ``dest`` differ, the file is read from ``source`` in the
+    template repository but written to ``dest`` in the downstream project.
+
+    Attributes:
+        source: Path of the file in the template repository.
+        dest: Path where the file should be placed in the downstream project.
+    """
+
+    source: str
+    dest: str
+
+    @property
+    def is_remapped(self) -> bool:
+        """True when the destination path differs from the source path."""
+        return self.source != self.dest
+
+    @classmethod
+    def from_config_entry(cls, entry: "str | dict[str, str]") -> "BundleFileEntry":
+        """Parse a file entry from a YAML config value (string or dict).
+
+        Args:
+            entry: Either a plain path string or a ``{source, dest}`` dict.
+
+        Returns:
+            A :class:`BundleFileEntry` instance.
+
+        Raises:
+            TypeError: If the entry is a dict without a ``source`` key.
+        """
+        if isinstance(entry, str):
+            return cls(source=entry, dest=entry)
+        if not isinstance(entry, dict) or "source" not in entry:
+            raise TypeError(  # noqa: TRY003
+                f"File entry must be a string or a dict with a 'source' key, got: {entry!r}"
+            )
+        source = entry["source"]
+        dest = entry.get("dest", source)
+        return cls(source=source, dest=dest)
+
+    def to_config_entry(self) -> "str | dict[str, str]":
+        """Serialize back to the YAML config representation."""
+        if not self.is_remapped:
+            return self.source
+        return {"source": self.source, "dest": self.dest}
+
+    def remap_expanded_path(self, expanded_source: str) -> str:
+        """Map an expanded source path to its destination path.
+
+        Handles both exact file matches and directory-prefix matches.
+
+        Args:
+            expanded_source: A source path produced by expanding this entry.
+
+        Returns:
+            The corresponding destination path.
+        """
+        if not self.is_remapped:
+            return expanded_source
+        if expanded_source == self.source:
+            return self.dest
+        src_prefix = self.source.rstrip("/") + "/"
+        if expanded_source.startswith(src_prefix):
+            dest_prefix = self.dest.rstrip("/") + "/"
+            return dest_prefix + expanded_source[len(src_prefix) :]
+        return expanded_source
+
+
 @dataclass(frozen=True, kw_only=True)
 class ProfileDefinition:
     """Represents a single profile from template-bundles.yml.
@@ -26,7 +97,7 @@ class BundleDefinition:
 
     Attributes:
         description: Human-readable description of the bundle.
-        files: List of file paths included in this bundle.
+        files: List of file entries included in this bundle.
         requires: List of bundle names that this bundle requires.
         standalone: Whether this bundle is standalone (no dependencies).
     """
@@ -34,7 +105,7 @@ class BundleDefinition:
     # name: str
     description: str
     standalone: bool = True
-    files: list[str] = field(default_factory=list)
+    files: list[BundleFileEntry] = field(default_factory=list)
     requires: list[str] = field(default_factory=list)
 
 
@@ -63,7 +134,7 @@ class RhizaBundles(YamlSerializable):
         for name, bundle in self.bundles.items():
             bundle_entry: dict[str, Any] = {"description": bundle.description}
             if bundle.files:
-                bundle_entry["files"] = bundle.files
+                bundle_entry["files"] = [f.to_config_entry() for f in bundle.files]
             if bundle.requires:
                 bundle_entry["requires"] = bundle.requires
             if bundle.standalone:
@@ -110,7 +181,13 @@ class RhizaBundles(YamlSerializable):
                 msg = f"Bundle '{bundle_name}' must be a dictionary"
                 raise TypeError(msg)
 
-            files = _normalize_to_list(bundle_data.get("files"))
+            raw_files = bundle_data.get("files")
+            if isinstance(raw_files, list):
+                files = [BundleFileEntry.from_config_entry(e) for e in raw_files]
+            elif isinstance(raw_files, str):
+                files = [BundleFileEntry.from_config_entry(e) for e in _normalize_to_list(raw_files)]
+            else:
+                files = []
             requires = _normalize_to_list(bundle_data.get("requires"))
 
             bundles[bundle_name] = BundleDefinition(
@@ -179,12 +256,52 @@ class RhizaBundles(YamlSerializable):
 
         for bundle_name in bundles:
             bundle = self.bundles[bundle_name]
-            for path in bundle.files:
-                if path not in seen:
-                    paths.append(path)
-                    seen.add(path)
+            for entry in bundle.files:
+                if entry.source not in seen:
+                    paths.append(entry.source)
+                    seen.add(entry.source)
 
         return paths
+
+    def resolve_to_path_map(self, bundle_names: list[str]) -> dict[str, str]:
+        """Return a source→destination mapping for all remapped file entries.
+
+        Plain (non-remapped) entries are excluded — callers can assume an
+        absent key means ``dest == source``.
+
+        Args:
+            bundle_names: List of bundle names to resolve (dependencies included).
+
+        Returns:
+            Dict mapping source path → destination path for remapped entries only.
+        """
+        path_map: dict[str, str] = {}
+        resolved = self.resolve_to_paths(bundle_names)
+        resolved_set = set(resolved)
+
+        seen: set[str] = set()
+        bundle_order: list[str] = []
+        resolving: set[str] = set()
+
+        def _collect(name: str) -> None:
+            if name not in self.bundles or name in resolving or name in seen:
+                return
+            resolving.add(name)
+            for dep in self.bundles[name].requires:
+                _collect(dep)
+            resolving.remove(name)
+            seen.add(name)
+            bundle_order.append(name)
+
+        for name in bundle_names:
+            _collect(name)
+
+        for bundle_name in bundle_order:
+            for entry in self.bundles[bundle_name].files:
+                if entry.source in resolved_set and entry.is_remapped:
+                    path_map[entry.source] = entry.dest
+
+        return path_map
 
     def resolve_profile_to_paths(self, profile_name: str) -> list[str]:
         """Resolve a profile name to deduplicated file paths.

--- a/tests/test_commands/test_sync_e2e.py
+++ b/tests/test_commands/test_sync_e2e.py
@@ -527,7 +527,7 @@ class TestSyncE2EUpdatedTemplateYml:
         (upstream_dir_v1 / "file_b.txt").write_text("content b\n")
 
         def clone_v1(template, git_ctx_, branch="main"):
-            return upstream_dir_v1, "sha_v1", list(template.include)
+            return upstream_dir_v1, "sha_v1", list(template.include), {}
 
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_v1):
             sync(target=project, branch="main", target_branch=None, strategy="merge")
@@ -558,7 +558,7 @@ class TestSyncE2EUpdatedTemplateYml:
         (upstream_dir_v2 / "file_c.txt").write_text("content c\n")
 
         def clone_v2(template, git_ctx_, branch="main"):
-            return upstream_dir_v2, "sha_v2", list(template.include)
+            return upstream_dir_v2, "sha_v2", list(template.include), {}
 
         def populate_base(git_url, sha, dest, include_paths):
             """Base snapshot contains only the files present at sha_v1."""
@@ -606,7 +606,7 @@ class TestSyncE2EUpdatedTemplateYml:
         (upstream_dir_v1 / "file_b.txt").write_text("content b\n")
 
         def clone_v1(template, git_ctx_, branch="main"):
-            return upstream_dir_v1, "sha_v1", list(template.include)
+            return upstream_dir_v1, "sha_v1", list(template.include), {}
 
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_v1):
             sync(target=project, branch="main", target_branch=None, strategy="merge")
@@ -634,7 +634,7 @@ class TestSyncE2EUpdatedTemplateYml:
 
         def clone_v2(template, git_ctx_, branch="main"):
             # Only file_a.txt is in the updated include list from template.yml.
-            return upstream_dir_v2, "sha_v2", list(template.include)
+            return upstream_dir_v2, "sha_v2", list(template.include), {}
 
         def populate_base(git_url, sha, dest, include_paths):
             # Orphan cleanup uses the lock's ``files`` field, not the diff,
@@ -687,7 +687,7 @@ class TestSyncE2ECustomPaths:
         (upstream / "special.txt").write_text("from custom template\n")
 
         def clone_upstream(template, git_ctx_, branch="main"):
-            return upstream, "sha_custom", list(template.include)
+            return upstream, "sha_custom", list(template.include), {}
 
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_upstream):
             sync(
@@ -726,7 +726,7 @@ class TestSyncE2ECustomPaths:
         (upstream / "app.txt").write_text("root level\n")
 
         def clone_upstream(template, git_ctx_, branch="main"):
-            return upstream, "sha_root", list(template.include)
+            return upstream, "sha_root", list(template.include), {}
 
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_upstream):
             sync(
@@ -766,7 +766,7 @@ class TestSyncE2ECustomPaths:
         (upstream_v1 / "data.txt").write_text("version 1\n")
 
         def clone_v1(template, git_ctx_, branch="main"):
-            return upstream_v1, "sha_v1", list(template.include)
+            return upstream_v1, "sha_v1", list(template.include), {}
 
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_v1):
             sync(
@@ -790,7 +790,7 @@ class TestSyncE2ECustomPaths:
         (upstream_v2 / "data.txt").write_text("version 2\n")
 
         def clone_v2(template, git_ctx_, branch="main"):
-            return upstream_v2, "sha_v2", list(template.include)
+            return upstream_v2, "sha_v2", list(template.include), {}
 
         def populate_base(git_url, sha, dest, include_paths):
             (dest / "data.txt").write_text("version 1\n")
@@ -832,7 +832,7 @@ class TestSyncE2ECustomPaths:
         (upstream / "cli_test.txt").write_text("cli driven\n")
 
         def clone_upstream(template, git_ctx_, branch="main"):
-            return upstream, "sha_cli", list(template.include)
+            return upstream, "sha_cli", list(template.include), {}
 
         runner = CliRunner()
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_upstream):
@@ -864,7 +864,7 @@ class TestSyncE2ECustomPaths:
         (upstream / "Makefile").write_text("install:\n\tpip install .\n")
 
         def clone_upstream(template, git_ctx_, branch="main"):
-            return upstream, "sha_dot", list(template.include)
+            return upstream, "sha_dot", list(template.include), {}
 
         runner = CliRunner()
         with patch("rhiza.commands.sync._clone_template", side_effect=clone_upstream):

--- a/tests/test_models/test_bundle_model.py
+++ b/tests/test_models/test_bundle_model.py
@@ -88,6 +88,13 @@ class TestRhizaBundlesConfig:
         assert restored.bundles["core"].files == original.bundles["core"].files
         assert restored.bundles["ci"].requires == original.bundles["ci"].requires
 
+    def test_files_as_string_normalised_to_list(self):
+        """A bundle's files field accepts a plain string and normalises it to a list."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        b = RhizaBundles.from_config({"bundles": {"core": {"files": "Makefile"}}})
+        assert b.bundles["core"].files == [BundleFileEntry(source="Makefile", dest="Makefile")]
+
 
 # ---------------------------------------------------------------------------
 # from_config error paths
@@ -385,6 +392,13 @@ class TestBundleFileEntry:
         entry = BundleFileEntry.from_config_entry({"source": ".rhiza/stubs/ci.yml", "dest": ".github/workflows/ci.yml"})
         assert entry.remap_expanded_path("other/file.yml") == "other/file.yml"
 
+    def test_remap_non_remapped_entry_returns_expanded_source(self):
+        """remap_expanded_path returns expanded_source unchanged for non-remapped entries."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry("Makefile")
+        assert entry.remap_expanded_path("Makefile") == "Makefile"
+
 
 class TestResolveToPathsWithRemappedEntries:
     """Tests for resolve_to_paths and resolve_to_path_map with remapped files."""
@@ -434,6 +448,25 @@ class TestResolveToPathsWithRemappedEntries:
         entry = restored.bundles["github-ci"].files[0]
         assert entry.source == ".rhiza/stubs/workflows/rhiza_ci.yml"
         assert entry.dest == ".github/workflows/rhiza_ci.yml"
+
+    def test_resolve_to_path_map_with_shared_dependency(self):
+        """resolve_to_path_map deduplicates bundles that share a common dependency."""
+        bundles = RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "core": {"description": "Core", "files": ["Makefile"]},
+                    "tests": {"description": "Tests", "requires": ["core"], "files": ["pytest.ini"]},
+                    "ci": {
+                        "description": "CI",
+                        "requires": ["core"],
+                        "files": [{"source": ".rhiza/stubs/ci.yml", "dest": ".github/workflows/ci.yml"}],
+                    },
+                }
+            }
+        )
+        # Both tests and ci require core; the shared-dep guard (name in seen) is exercised.
+        path_map = bundles.resolve_to_path_map(["tests", "ci"])
+        assert path_map == {".rhiza/stubs/ci.yml": ".github/workflows/ci.yml"}
 
 
 class TestResolveProfileToPaths:

--- a/tests/test_models/test_bundle_model.py
+++ b/tests/test_models/test_bundle_model.py
@@ -309,6 +309,133 @@ class TestProfileDefinition:
         assert "description" not in bundles.config["profiles"]["minimal"]
 
 
+class TestBundleFileEntry:
+    """Tests for BundleFileEntry parsing and path remapping."""
+
+    def test_string_entry_source_equals_dest(self):
+        """A plain string entry has source == dest."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry("Makefile")
+        assert entry.source == "Makefile"
+        assert entry.dest == "Makefile"
+        assert not entry.is_remapped
+
+    def test_dict_entry_with_dest(self):
+        """A dict entry with source and dest is parsed correctly."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry(
+            {"source": ".rhiza/stubs/workflows/ci.yml", "dest": ".github/workflows/ci.yml"}
+        )
+        assert entry.source == ".rhiza/stubs/workflows/ci.yml"
+        assert entry.dest == ".github/workflows/ci.yml"
+        assert entry.is_remapped
+
+    def test_dict_entry_without_dest_falls_back_to_source(self):
+        """A dict entry with only source defaults dest to source."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry({"source": "Makefile"})
+        assert entry.dest == "Makefile"
+        assert not entry.is_remapped
+
+    def test_dict_entry_missing_source_raises(self):
+        """TypeError raised when dict entry has no source key."""
+        import pytest
+
+        from rhiza.models.bundle import BundleFileEntry
+
+        with pytest.raises(TypeError, match="source"):
+            BundleFileEntry.from_config_entry({"dest": "Makefile"})
+
+    def test_to_config_entry_plain_string_roundtrip(self):
+        """Non-remapped entry serialises back to a plain string."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry("Makefile")
+        assert entry.to_config_entry() == "Makefile"
+
+    def test_to_config_entry_remapped_roundtrip(self):
+        """Remapped entry serialises back to a dict."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        raw = {"source": ".rhiza/stubs/workflows/ci.yml", "dest": ".github/workflows/ci.yml"}
+        entry = BundleFileEntry.from_config_entry(raw)
+        assert entry.to_config_entry() == raw
+
+    def test_remap_exact_file(self):
+        """remap_expanded_path maps an exact file path."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry({"source": ".rhiza/stubs/ci.yml", "dest": ".github/workflows/ci.yml"})
+        assert entry.remap_expanded_path(".rhiza/stubs/ci.yml") == ".github/workflows/ci.yml"
+
+    def test_remap_directory_prefix(self):
+        """remap_expanded_path applies prefix substitution for directory entries."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry({"source": ".rhiza/stubs/workflows", "dest": ".github/workflows"})
+        assert entry.remap_expanded_path(".rhiza/stubs/workflows/ci.yml") == ".github/workflows/ci.yml"
+
+    def test_remap_non_matching_path_unchanged(self):
+        """remap_expanded_path returns the source unchanged when it doesn't match."""
+        from rhiza.models.bundle import BundleFileEntry
+
+        entry = BundleFileEntry.from_config_entry({"source": ".rhiza/stubs/ci.yml", "dest": ".github/workflows/ci.yml"})
+        assert entry.remap_expanded_path("other/file.yml") == "other/file.yml"
+
+
+class TestResolveToPathsWithRemappedEntries:
+    """Tests for resolve_to_paths and resolve_to_path_map with remapped files."""
+
+    def _make_bundles(self):
+        return RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "core": {"description": "Core", "files": ["Makefile"]},
+                    "github-ci": {
+                        "description": "CI workflows",
+                        "requires": ["core"],
+                        "files": [
+                            {
+                                "source": ".rhiza/stubs/workflows/rhiza_ci.yml",
+                                "dest": ".github/workflows/rhiza_ci.yml",
+                            }
+                        ],
+                    },
+                }
+            }
+        )
+
+    def test_resolve_to_paths_returns_source_paths(self):
+        """resolve_to_paths returns source paths (used for sparse checkout)."""
+        bundles = self._make_bundles()
+        result = bundles.resolve_to_paths(["github-ci"])
+        assert ".rhiza/stubs/workflows/rhiza_ci.yml" in result
+        assert ".github/workflows/rhiza_ci.yml" not in result
+
+    def test_resolve_to_path_map_returns_remapped_entries_only(self):
+        """resolve_to_path_map only includes entries where source != dest."""
+        bundles = self._make_bundles()
+        path_map = bundles.resolve_to_path_map(["github-ci"])
+        assert path_map == {".rhiza/stubs/workflows/rhiza_ci.yml": ".github/workflows/rhiza_ci.yml"}
+        assert "Makefile" not in path_map
+
+    def test_resolve_to_path_map_empty_when_no_remapping(self):
+        """resolve_to_path_map is empty when no entries are remapped."""
+        bundles = self._make_bundles()
+        assert bundles.resolve_to_path_map(["core"]) == {}
+
+    def test_config_round_trips_remapped_files(self):
+        """Remapped file entries survive a config round-trip."""
+        bundles = self._make_bundles()
+        restored = RhizaBundles.from_config(bundles.config)
+        entry = restored.bundles["github-ci"].files[0]
+        assert entry.source == ".rhiza/stubs/workflows/rhiza_ci.yml"
+        assert entry.dest == ".github/workflows/rhiza_ci.yml"
+
+
 class TestResolveProfileToPaths:
     """Tests for RhizaBundles.resolve_profile_to_paths."""
 

--- a/tests/test_models/test_models_comprehensive.py
+++ b/tests/test_models/test_models_comprehensive.py
@@ -17,7 +17,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from rhiza.models._base import YamlSerializable, load_model, read_yaml
-from rhiza.models.bundle import RhizaBundles
+from rhiza.models.bundle import BundleFileEntry, RhizaBundles
 from rhiza.models.lock import TemplateLock
 from rhiza.models.template import GitHost, RhizaTemplate
 
@@ -513,7 +513,7 @@ class TestRhizaBundlesE2E:
         restored = RhizaBundles.from_yaml(path)
         assert restored.version == b.version
         assert set(restored.bundles.keys()) == set(b.bundles.keys())
-        assert restored.bundles["core"].files == ["Makefile"]
+        assert restored.bundles["core"].files == [BundleFileEntry(source="Makefile", dest="Makefile")]
         assert restored.bundles["ci"].requires == ["core"]
 
     def test_load_model_helper(self, tmp_path):

--- a/tests/test_models/test_template_model.py
+++ b/tests/test_models/test_template_model.py
@@ -348,7 +348,9 @@ class TestRhizaTemplateClone:
             include=["Makefile", ".github"],
         )
 
-        upstream_dir, upstream_sha, resolved_include = _clone_template(template, GitContext.default(), branch="main")
+        upstream_dir, upstream_sha, resolved_include, _path_map = _clone_template(
+            template, GitContext.default(), branch="main"
+        )
 
         assert upstream_dir.is_dir()
         assert upstream_sha == "abc123def456"
@@ -441,7 +443,7 @@ class TestRhizaTemplateClone:
             profiles=["local"],
         )
 
-        upstream_dir, upstream_sha, resolved = _clone_template(template, GitContext.default())
+        upstream_dir, upstream_sha, resolved, _path_map = _clone_template(template, GitContext.default())
 
         assert upstream_sha == "sha_profile"
         assert "Makefile" in resolved
@@ -460,7 +462,9 @@ class TestRhizaTemplateClone:
             include=["Makefile"],
         )
 
-        upstream_dir, upstream_sha, _resolved = _clone_template(template, GitContext.default(), branch="main")
+        upstream_dir, upstream_sha, _resolved, _path_map = _clone_template(
+            template, GitContext.default(), branch="main"
+        )
 
         # The clone should use 'develop' (template_branch), not 'main' (default arg).
         mock_clone.assert_called_once()

--- a/tests/test_models/test_template_model.py
+++ b/tests/test_models/test_template_model.py
@@ -16,7 +16,7 @@ import yaml
 from rhiza.commands.sync import _clone_template, _load_template_from_project
 from rhiza.models import GitContext
 from rhiza.models._base import YamlSerializable, load_model
-from rhiza.models._git_utils import _excluded_set, _expand_paths, _prepare_snapshot
+from rhiza.models._git_utils import _excluded_set, _expand_paths, _prepare_snapshot, _remap_path
 from rhiza.models.template import RhizaTemplate
 
 
@@ -781,3 +781,19 @@ class TestFromProject:
         with patch("rhiza.commands.validate.validate", return_value=True):
             template = _load_template_from_project(tmp_path)
         assert template.exclude == ["secret.txt"]
+
+
+class TestRemapPath:
+    """Tests for _remap_path."""
+
+    def test_direct_key_match_returns_mapped_dest(self):
+        """Returns the mapped destination for an exact source key."""
+        assert _remap_path("Makefile", {"Makefile": "dest/Makefile"}) == "dest/Makefile"
+
+    def test_directory_prefix_match_substitutes_prefix(self):
+        """Replaces a directory prefix when source starts with <key>/."""
+        assert _remap_path(".rhiza/stubs/ci.yml", {".rhiza/stubs": ".github/workflows"}) == ".github/workflows/ci.yml"
+
+    def test_no_match_returns_source_unchanged(self):
+        """Returns source unchanged when no key matches."""
+        assert _remap_path("other.txt", {"Makefile": "dest/Makefile"}) == "other.txt"


### PR DESCRIPTION
## Summary

- Add `BundleFileEntry` dataclass supporting `{source, dest}` dict syntax alongside plain strings in bundle `files:` lists
- Add `resolve_to_path_map()` on `RhizaBundles` returning source→dest mappings for remapped entries
- Add `_remap_path()` helper with exact-file and directory-prefix matching
- `_prepare_snapshot()` writes files to their destination paths when a `path_map` is provided, so diffs and merges operate on the correct target locations
- Thread `path_map` through `_clone_template`, `sync_merge`, and `_merge_with_base`
- 13 new tests covering `BundleFileEntry` parsing, remapping, round-trips, and `resolve_to_path_map`

## Motivation

Enables workflow stubs to live at `.rhiza/stubs/workflows/` in the template repo and be synced to `.github/workflows/` in downstream projects — resolving the path conflict between reusable workflow implementations and the stubs that call them.

## Test plan

- [ ] All 39 bundle model tests pass
- [ ] Existing sync behaviour unchanged for plain-string file entries (backward compatible)
- [ ] Remapped entries land at `dest` path in downstream repo after `rhiza sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)