### PR TITLE
feat: support directory-based bundle resolution for template-bundles.yml v0.13.3+

### DIFF
--- a/src/rhiza/models/_git_utils.py
+++ b/src/rhiza/models/_git_utils.py
@@ -962,8 +962,10 @@ def _remap_path(source: str, path_map: dict[str, str]) -> str:
     for src, dest in path_map.items():
         src_prefix = src.rstrip("/") + "/"
         if source.startswith(src_prefix):
-            dest_prefix = dest.rstrip("/") + "/"
-            return dest_prefix + source[len(src_prefix) :]
+            suffix = source[len(src_prefix) :]
+            if dest.rstrip("/"):
+                return dest.rstrip("/") + "/" + suffix
+            return suffix
     return source
 
 

--- a/src/rhiza/models/bundle.py
+++ b/src/rhiza/models/bundle.py
@@ -97,16 +97,22 @@ class BundleDefinition:
 
     Attributes:
         description: Human-readable description of the bundle.
-        files: List of file entries included in this bundle.
+        files: Explicit file entries (legacy format only — new bundles own files via
+            their ``bundles/<name>/`` directory in the template repository).
         requires: List of bundle names that this bundle requires.
+        recommends: List of bundle names that this bundle recommends (soft deps).
         standalone: Whether this bundle is standalone (no dependencies).
+        required: Whether this bundle is mandatory (always included).
+        notes: Free-form notes for maintainers (not synced to downstream projects).
     """
 
-    # name: str
     description: str
     standalone: bool = True
+    required: bool = False
     files: list[BundleFileEntry] = field(default_factory=list)
     requires: list[str] = field(default_factory=list)
+    recommends: list[str] = field(default_factory=list)
+    notes: str = ""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -133,12 +139,18 @@ class RhizaBundles(YamlSerializable):
         bundles_dict: dict[str, Any] = {}
         for name, bundle in self.bundles.items():
             bundle_entry: dict[str, Any] = {"description": bundle.description}
-            if bundle.files:
-                bundle_entry["files"] = [f.to_config_entry() for f in bundle.files]
-            if bundle.requires:
-                bundle_entry["requires"] = bundle.requires
+            if bundle.required:
+                bundle_entry["required"] = bundle.required
             if bundle.standalone:
                 bundle_entry["standalone"] = bundle.standalone
+            if bundle.requires:
+                bundle_entry["requires"] = bundle.requires
+            if bundle.recommends:
+                bundle_entry["recommends"] = bundle.recommends
+            if bundle.files:
+                bundle_entry["files"] = [f.to_config_entry() for f in bundle.files]
+            if bundle.notes:
+                bundle_entry["notes"] = bundle.notes
             bundles_dict[name] = bundle_entry
 
         config["bundles"] = bundles_dict
@@ -194,7 +206,10 @@ class RhizaBundles(YamlSerializable):
                 description=bundle_data.get("description", ""),
                 files=files,
                 requires=requires,
+                recommends=_normalize_to_list(bundle_data.get("recommends")),
                 standalone=bundle_data.get("standalone", True),
+                required=bool(bundle_data.get("required", False)),
+                notes=bundle_data.get("notes") or "",
             )
 
         profiles_config = config.get("profiles", {})
@@ -256,10 +271,16 @@ class RhizaBundles(YamlSerializable):
 
         for bundle_name in bundles:
             bundle = self.bundles[bundle_name]
-            for entry in bundle.files:
-                if entry.source not in seen:
-                    paths.append(entry.source)
-                    seen.add(entry.source)
+            if bundle.files:
+                for entry in bundle.files:
+                    if entry.source not in seen:
+                        paths.append(entry.source)
+                        seen.add(entry.source)
+            else:
+                dir_path = f"bundles/{bundle_name}/"
+                if dir_path not in seen:
+                    paths.append(dir_path)
+                    seen.add(dir_path)
 
         return paths
 
@@ -297,9 +318,13 @@ class RhizaBundles(YamlSerializable):
             _collect(name)
 
         for bundle_name in bundle_order:
-            for entry in self.bundles[bundle_name].files:
-                if entry.source in resolved_set and entry.is_remapped:
-                    path_map[entry.source] = entry.dest
+            bundle = self.bundles[bundle_name]
+            if bundle.files:
+                for entry in bundle.files:
+                    if entry.source in resolved_set and entry.is_remapped:
+                        path_map[entry.source] = entry.dest
+            else:
+                path_map[f"bundles/{bundle_name}/"] = ""
 
         return path_map
 

--- a/tests/test_models/test_bundle_model.py
+++ b/tests/test_models/test_bundle_model.py
@@ -66,11 +66,14 @@ class TestRhizaBundlesConfig:
         assert bundles.config["version"] == "2"
 
     def test_config_omits_empty_files_and_workflows(self):
-        """Files and workflows keys are omitted when empty."""
+        """Files, workflows, and new optional fields are omitted when empty/default."""
         bundles = RhizaBundles.from_config({"bundles": {"core": {"description": "Core"}}})
         entry = bundles.config["bundles"]["core"]
         assert "files" not in entry
         assert "workflows" not in entry
+        assert "recommends" not in entry
+        assert "notes" not in entry
+        assert "required" not in entry
 
     def test_config_round_trips_through_from_config(self):
         """Config output can be fed back into from_config producing an equal object."""
@@ -314,6 +317,151 @@ class TestProfileDefinition:
             }
         )
         assert "description" not in bundles.config["profiles"]["minimal"]
+
+
+class TestBundleDefinitionNewFields:
+    """Tests for the new BundleDefinition fields: required, recommends, notes."""
+
+    def test_required_field_parsed(self):
+        """required: true is parsed from config."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core", "required": True}}})
+        assert b.bundles["core"].required is True
+
+    def test_required_defaults_to_false(self):
+        """Required defaults to False when absent."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core"}}})
+        assert b.bundles["core"].required is False
+
+    def test_recommends_parsed(self):
+        """Recommends list is parsed from config."""
+        b = RhizaBundles.from_config({"bundles": {"book": {"description": "Book", "recommends": ["tests", "marimo"]}}})
+        assert b.bundles["book"].recommends == ["tests", "marimo"]
+
+    def test_recommends_defaults_to_empty(self):
+        """Recommends defaults to [] when absent."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core"}}})
+        assert b.bundles["core"].recommends == []
+
+    def test_notes_parsed(self):
+        """Notes string is parsed from config."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core", "notes": "See readme"}}})
+        assert b.bundles["core"].notes == "See readme"
+
+    def test_notes_defaults_to_empty(self):
+        """Notes defaults to empty string when absent."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core"}}})
+        assert b.bundles["core"].notes == ""
+
+    def test_required_serialised_when_true(self):
+        """required: True appears in config output."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core", "required": True}}})
+        assert b.config["bundles"]["core"]["required"] is True
+
+    def test_recommends_serialised_when_present(self):
+        """Recommends list appears in config output when non-empty."""
+        b = RhizaBundles.from_config({"bundles": {"book": {"description": "Book", "recommends": ["tests"]}}})
+        assert b.config["bundles"]["book"]["recommends"] == ["tests"]
+
+    def test_notes_serialised_when_present(self):
+        """Notes appears in config output when non-empty."""
+        b = RhizaBundles.from_config({"bundles": {"core": {"description": "Core", "notes": "See readme"}}})
+        assert b.config["bundles"]["core"]["notes"] == "See readme"
+
+    def test_new_fields_round_trip(self):
+        """New fields survive a config round-trip."""
+        original = RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "core": {"description": "Core", "required": True},
+                    "book": {"description": "Book", "recommends": ["tests"], "notes": "Needs marimo"},
+                }
+            }
+        )
+        restored = RhizaBundles.from_config(original.config)
+        assert restored.bundles["core"].required is True
+        assert restored.bundles["book"].recommends == ["tests"]
+        assert restored.bundles["book"].notes == "Needs marimo"
+
+
+class TestDirectoryBasedResolution:
+    """Tests for bundles without explicit files resolved via bundles/<name>/ directories."""
+
+    def _make_dir_bundles(self):
+        return RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "core": {"description": "Core", "required": True, "standalone": True},
+                    "tests": {"description": "Tests", "standalone": True, "requires": ["core"]},
+                    "github-tests": {"description": "GitHub Tests", "standalone": True, "requires": ["tests"]},
+                }
+            }
+        )
+
+    def test_resolve_to_paths_returns_bundle_dirs(self):
+        """Bundles without files resolve to bundles/<name>/ directory paths."""
+        b = self._make_dir_bundles()
+        result = b.resolve_to_paths(["core"])
+        assert result == ["bundles/core/"]
+
+    def test_resolve_to_paths_includes_transitive_deps(self):
+        """Transitive requires are resolved to bundle directory paths."""
+        b = self._make_dir_bundles()
+        result = b.resolve_to_paths(["tests"])
+        assert "bundles/core/" in result
+        assert "bundles/tests/" in result
+
+    def test_resolve_to_paths_deduplicates_dirs(self):
+        """Each bundle directory appears only once even when shared across deps."""
+        b = self._make_dir_bundles()
+        result = b.resolve_to_paths(["github-tests", "tests"])
+        assert result.count("bundles/core/") == 1
+        assert result.count("bundles/tests/") == 1
+
+    def test_resolve_to_path_map_returns_dir_prefix_to_root(self):
+        """resolve_to_path_map maps bundles/<name>/ → '' for directory-based bundles."""
+        b = self._make_dir_bundles()
+        path_map = b.resolve_to_path_map(["core"])
+        assert path_map == {"bundles/core/": ""}
+
+    def test_resolve_to_path_map_covers_all_resolved_bundles(self):
+        """path_map includes an entry for every bundle in the resolved set."""
+        b = self._make_dir_bundles()
+        path_map = b.resolve_to_path_map(["tests"])
+        assert "bundles/core/" in path_map
+        assert "bundles/tests/" in path_map
+        assert all(v == "" for v in path_map.values())
+
+    def test_mixed_format_explicit_files_bundle_uses_paths(self):
+        """A bundle with explicit files still uses the old path-based resolution."""
+        b = RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "core": {"description": "Core", "files": ["Makefile", "pyproject.toml"]},
+                    "tests": {"description": "Tests", "requires": ["core"]},
+                }
+            }
+        )
+        result = b.resolve_to_paths(["tests"])
+        assert "Makefile" in result
+        assert "pyproject.toml" in result
+        assert "bundles/tests/" in result
+
+    def test_mixed_format_path_map_blends_old_and_new(self):
+        """path_map mixes explicit remaps (old) with dir prefix (new)."""
+        b = RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "core": {
+                        "description": "Core",
+                        "files": [{"source": ".rhiza/stubs/ci.yml", "dest": ".github/workflows/ci.yml"}],
+                    },
+                    "tests": {"description": "Tests", "requires": ["core"]},
+                }
+            }
+        )
+        path_map = b.resolve_to_path_map(["tests"])
+        assert path_map[".rhiza/stubs/ci.yml"] == ".github/workflows/ci.yml"
+        assert path_map["bundles/tests/"] == ""
 
 
 class TestBundleFileEntry:

--- a/tests/test_models/test_template_model.py
+++ b/tests/test_models/test_template_model.py
@@ -797,3 +797,20 @@ class TestRemapPath:
     def test_no_match_returns_source_unchanged(self):
         """Returns source unchanged when no key matches."""
         assert _remap_path("other.txt", {"Makefile": "dest/Makefile"}) == "other.txt"
+
+    def test_empty_dest_strips_bundle_prefix_to_root(self):
+        """Empty dest maps bundles/<name>/file.txt → file.txt (directory-based bundle resolution)."""
+        assert _remap_path("bundles/core/Makefile", {"bundles/core/": ""}) == "Makefile"
+
+    def test_empty_dest_strips_nested_path(self):
+        """Empty dest handles nested paths correctly."""
+        assert (
+            _remap_path("bundles/github-tests/.github/workflows/ci.yml", {"bundles/github-tests/": ""})
+            == ".github/workflows/ci.yml"
+        )
+
+    def test_empty_dest_no_leading_slash(self):
+        """Empty dest does not produce a leading slash in the result."""
+        result = _remap_path("bundles/tests/pytest.ini", {"bundles/tests/": ""})
+        assert not result.startswith("/")
+        assert result == "pytest.ini"


### PR DESCRIPTION
## Summary

- `template-bundles.yml` v0.13.3+ no longer lists `files:` in bundles — ownership is now expressed via `bundles/<name>/` directories in the template repository
- Add `required`, `recommends`, and `notes` fields to `BundleDefinition` to match the new schema
- `resolve_to_paths()` and `resolve_to_path_map()` now return `bundles/<name>/` directory paths (and corresponding prefix-strip entries) for bundles without explicit `files:`
- Fix `_remap_path()` to handle an empty-string dest (root mapping) — previously would produce `/Makefile` instead of `Makefile`
- Old format with explicit `files:` continues to work unchanged (backward compatible)

## Test plan

- [ ] New `TestBundleDefinitionNewFields` class covers `required`, `recommends`, `notes` parse/serialize/round-trip
- [ ] New `TestDirectoryBasedResolution` class covers `resolve_to_paths` and `resolve_to_path_map` for file-less bundles, including transitive deps, deduplication, and mixed old/new format
- [ ] New `TestRemapPath` cases cover empty-dest prefix stripping (root mapping, nested paths, no leading slash)
- [ ] Full test suite: 612 tests passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)