### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -92,5 +92,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-05-28T16:44:06Z'
+synced_at: '2026-06-08T00:52:55Z'
 strategy: merge

--- a/pyproject.toml.template
+++ b/pyproject.toml.template
@@ -1,0 +1,12 @@
+[project]
+name = "your-project"
+version = "0.1.0"
+description = "A Rhiza-based Python project"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+lint = []
+test = []
+docs = []


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **1** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Other

<details>
<summary>Added (1)</summary>

- ✅ `pyproject.toml.template`

</details>

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@v0.18.4`
- Last sync: 2026-06-08T00:52:55Z
- Sync date: 2026-06-08T00:52:56.385303+00:00