### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_commands/test_init.py
+++ b/tests/test_commands/test_init.py
@@ -5,8 +5,8 @@ that the Typer CLI entry `rhiza init` works as expected.
 """
 
 import subprocess  # nosec B404
-from urllib.parse import urlparse
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 import yaml

--- a/tests/test_commands/test_init.py
+++ b/tests/test_commands/test_init.py
@@ -5,6 +5,7 @@ that the Typer CLI entry `rhiza init` works as expected.
 """
 
 import subprocess  # nosec B404
+from urllib.parse import urlparse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -931,7 +932,8 @@ class TestGetLatestTag:
         mock_run.return_value = MagicMock(returncode=0, stdout="")
         _get_latest_tag("owner/repo", git_host="gitlab")
         args = mock_run.call_args[0][0]
-        assert "gitlab.com" in " ".join(args)
+        remote_url = next((arg for arg in args if isinstance(arg, str) and arg.startswith(("http://", "https://"))), "")
+        assert urlparse(remote_url).hostname == "gitlab.com"
 
     def test_init_uses_latest_tag_as_ref(self, git_tmp_path):
         """init() writes the latest tag to ref in template.yml."""


### PR DESCRIPTION
Potential fix for [https://github.com/Jebel-Quant/rhiza-cli/security/code-scanning/7](https://github.com/Jebel-Quant/rhiza-cli/security/code-scanning/7)

Use URL parsing in the test assertion and compare the hostname directly.

Best fix in this file:
- In `tests/test_commands/test_init.py`, update `test_uses_gitlab_url_for_gitlab_host`.
- Keep extracting `args` from `mock_run.call_args` as-is.
- Find the URL argument passed to `git ls-remote` (the argument starting with `http://` or `https://`).
- Parse it using `urllib.parse.urlparse` and assert `parsed.hostname == "gitlab.com"`.

What is needed:
- Add `from urllib.parse import urlparse` import near the top of the file.
- Replace the weak substring assertion with host-based assertion logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
