### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/rhiza/commands/init.py
+++ b/src/rhiza/commands/init.py
@@ -11,6 +11,7 @@ import re
 import subprocess  # nosec B404
 import sys
 import urllib.error
+import urllib.parse
 from pathlib import Path
 
 import typer
@@ -212,10 +213,21 @@ def _detect_git_host(target: Path) -> GitHost | None:
         if result.returncode != 0:
             return None
         url = result.stdout.strip()
-        if "github.com" in url:
+
+        host: str | None = None
+        if "://" in url:
+            host = urllib.parse.urlparse(url).hostname
+        else:
+            # Handle SCP-like git remotes, e.g. git@github.com:org/repo.git
+            match = re.match(r"^(?:[^@]+@)?([^:]+):.+$", url)
+            if match:
+                host = match.group(1)
+
+        host = host.lower() if host else None
+        if host == "github.com":
             logger.debug(f"Detected git host: github (from {url})")
             return GitHost.GITHUB
-        if "gitlab.com" in url:
+        if host == "gitlab.com":
             logger.debug(f"Detected git host: gitlab (from {url})")
             return GitHost.GITLAB
     except (RuntimeError, OSError):


### PR DESCRIPTION
Potential fix for [https://github.com/Jebel-Quant/rhiza-cli/security/code-scanning/5](https://github.com/Jebel-Quant/rhiza-cli/security/code-scanning/5)

Use structured parsing of the git remote to extract the actual host, then compare that host exactly (or via safe suffix rules if needed).  
For this file, the best minimal fix is:

- In `src/rhiza/commands/init.py`, update `_detect_git_host`.
- Add `import urllib.parse`.
- Replace the substring checks with logic that:
  1. Handles scp-like git syntax (`git@github.com:org/repo.git`) by extracting host from the `user@host:path` pattern.
  2. Handles standard URL syntax (`https://...`, `ssh://...`) using `urllib.parse.urlparse(...).hostname`.
  3. Compares normalized host directly against `"github.com"` and `"gitlab.com"`.

This preserves existing behavior intent while removing incomplete URL sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
