### PR TITLE
docs: documentation map + fix Issues URL (#530, #531)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,5 +1,7 @@
 # Rhiza CLI Quick Reference
 
+> **📚 Documentation map** — [Getting Started](GETTING_STARTED.md) (start here) · [README](README.md) (overview & full command reference) · [Usage Guide](USAGE.md) (workflows & examples) · **CLI Reference** (you are here)
+
 This document provides a quick reference for the Rhiza command-line interface.
 
 ## Command Overview

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,5 +1,7 @@
 # Getting Started with Rhiza
 
+> **📚 Documentation map** — **Getting Started** (you are here, start here) · [README](README.md) (overview & full command reference) · [Usage Guide](USAGE.md) (workflows & examples) · [CLI Reference](CLI.md) (command cheatsheet)
+
 **Rhiza helps you keep multiple Python projects consistently configured** by using templates stored in central repositories. Instead of manually copying configuration files between projects, Rhiza automates synchronization and ensures your projects stay aligned.
 
 **More than just a template or starter project**, Rhiza is a **continuous synchronization system** that adapts as standards evolve.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 Command-line interface for managing reusable configuration templates for modern Python projects.
 
 **📖 New to Rhiza? Check out the [Getting Started Guide](GETTING_STARTED.md) for a beginner-friendly introduction!**
+
+📚 **Documentation map** — [Getting Started](GETTING_STARTED.md) (start here) · **README** (overview & full command reference) · [Usage Guide](USAGE.md) (workflows & examples) · [CLI Reference](CLI.md) (command cheatsheet)
 </div>
 
 ## Overview

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,5 +1,7 @@
 # Rhiza Usage Guide
 
+> **📚 Documentation map** — [Getting Started](GETTING_STARTED.md) (start here) · [README](README.md) (overview & full command reference) · **Usage Guide** (you are here) · [CLI Reference](CLI.md) (command cheatsheet)
+
 This guide provides practical examples and tutorials for using Rhiza CLI.
 
 ## Table of Contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/jebel-quant/rhiza-cli"
 Repository = "https://github.com/jebel-quant/rhiza-cli"
-Issues = "https://github.com/jebel-quant/rhiza-cli/issues-cli"
+Issues = "https://github.com/jebel-quant/rhiza-cli/issues"
 
 [project.optional-dependencies]
 tools = ["rhiza-tools>=0.1.2"]


### PR DESCRIPTION
## Summary

Addresses two of the four repository-analysis issues. The other two (#532 pytest `log_cli`, #533 ruff `ANN`) touch **Rhiza-managed** files (`pytest.ini`, `ruff.toml`) and must be changed upstream in `jebel-quant/rhiza` — see note below.

### Fixed here
- **#531** — Fix malformed `project.urls.Issues` in `pyproject.toml` (`/issues-cli` → `/issues`). This URL is published to PyPI.
- **#530** (light touch) — Add a consistent **Documentation map** nav block to `README.md`, `USAGE.md`, `CLI.md`, and `GETTING_STARTED.md`, establishing `GETTING_STARTED.md` as the canonical entry point and cross-linking the four root docs. No content rewrites — full consolidation can follow separately.

### Not in this PR (managed files)
- **#532** (`pytest.ini` `log_cli`) and **#533** (`ruff.toml` ANN rules) are owned by the upstream Rhiza template (`.rhiza/template.lock`). Editing them here would be overwritten on the next `make sync`. These need an upstream change + new Rhiza release.

## Verification
- `markdownlint` passes on all four docs.
- `Issues` URL parses to `https://github.com/jebel-quant/rhiza-cli/issues`.
- Pre-commit hooks pass.

Closes #530
Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)