### PR TITLE
chore(fuzz): use $SRC directly and pin pip in the ClusterFuzzLite build

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,6 +4,6 @@
 # changes through reviewed updates.
 FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:9c97273c8de83d22a40462fdda4371d1ff16eac065c72ee03bef7fdb1aaaf458
 
-COPY . $SRC/rhiza-cli
-WORKDIR $SRC/rhiza-cli
+COPY . $SRC
+WORKDIR $SRC
 COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -3,7 +3,11 @@
 # import `rhiza` at runtime, then compiles each Python harness in tests/fuzz/
 # via OSS-Fuzz's compile_python_fuzzer helper.
 
-cd "$SRC/rhiza-cli"
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
 
 # Install the package (src-layout) and its runtime deps into the build image so
 # PyInstaller can discover and bundle `rhiza` into each frozen fuzz binary.


### PR DESCRIPTION
Aligns rhiza-cli's `.clusterfuzzlite/` build with the setup now used in `jebel-quant/rhiza-hooks` and `rhiza-tools`.

- **Dockerfile**: `COPY`/`WORKDIR` use `$SRC` directly instead of a hardcoded `$SRC/rhiza-cli` subdirectory (base image stays SHA-pinned at its existing digest).
- **build.sh**: `cd "$SRC"` (no project-name path) and pin pip to `24.3.1` for a reproducible build.

The existing `tests/fuzz/fuzz_model_parse.py` target is unchanged. Set the `FUZZING_ENABLED` repo variable to `true` so the `(RHIZA) FUZZING` workflow runs and verifies the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)