### PR TITLE
refactor: reduce cyclomatic complexity of 6 ruff C901-flagged functions

### DIFF
--- a/src/rhiza/commands/validate.py
+++ b/src/rhiza/commands/validate.py
@@ -120,6 +120,35 @@ def _parse_yaml_file(template_file: Path) -> tuple[bool, dict[str, Any] | None]:
     return True, config
 
 
+def _validate_profiles_field(config: dict[str, Any]) -> bool | None:
+    """Validate the optional ``profiles`` field.
+
+    Args:
+        config: Configuration dictionary.
+
+    Returns:
+        ``None`` if no ``profiles`` field is present, ``True`` if it is present
+        and valid, ``False`` if it is present but invalid.
+    """
+    if "profiles" not in config:
+        return None
+
+    profiles = config["profiles"]
+    if not isinstance(profiles, list):
+        logger.error(f"profiles must be a list, got {type(profiles).__name__}")
+        logger.error("Example: profiles: [github-project]")
+        return False
+    if not profiles:
+        logger.error("profiles list cannot be empty")
+        logger.error("Example: profiles: [github-project]")
+        return False
+    for p in profiles:
+        if not isinstance(p, str) or not p.strip():
+            logger.error(f"Each entry in profiles must be a non-empty string, got: {p!r}")
+            return False
+    return True
+
+
 def _validate_configuration_mode(config: dict[str, Any]) -> bool:
     """Validate that at least one of profile, templates, or include is specified.
 
@@ -132,23 +161,11 @@ def _validate_configuration_mode(config: dict[str, Any]) -> bool:
     logger.debug("Validating configuration mode")
     has_templates = "templates" in config and config["templates"]
     has_include = "include" in config and config["include"]
-    has_profiles = False
 
-    if "profiles" in config:
-        profiles = config["profiles"]
-        if not isinstance(profiles, list):
-            logger.error(f"profiles must be a list, got {type(profiles).__name__}")
-            logger.error("Example: profiles: [github-project]")
-            return False
-        if not profiles:
-            logger.error("profiles list cannot be empty")
-            logger.error("Example: profiles: [github-project]")
-            return False
-        for p in profiles:
-            if not isinstance(p, str) or not p.strip():
-                logger.error(f"Each entry in profiles must be a non-empty string, got: {p!r}")
-                return False
-        has_profiles = True
+    profiles_valid = _validate_profiles_field(config)
+    if profiles_valid is False:
+        return False
+    has_profiles = profiles_valid is True
 
     # Error if old "bundles" field is used
     if "bundles" in config:

--- a/src/rhiza/models/_git/diff.py
+++ b/src/rhiza/models/_git/diff.py
@@ -1,11 +1,58 @@
 """Diff computation and parsing for the sync engine."""
 
 import subprocess  # nosec B404
+from dataclasses import dataclass
 from pathlib import Path
 
 from loguru import logger
 
 from rhiza.models._git._base import GitContextBase
+
+_SRC_PREFIX = "upstream-template-old/"
+_DST_PREFIX = "upstream-template-new/"
+
+
+def _path_after(line: str, marker: str, prefix: str) -> str | None:
+    """Return the diff path on a ``---``/``+++`` header line, stripped of *prefix*."""
+    raw = line[len(marker) :].strip().strip('"').split("\t")[0]
+    if raw != "/dev/null" and raw.startswith(prefix):
+        return raw[len(prefix) :]
+    return None
+
+
+@dataclass
+class _DiffFileState:
+    """Accumulates the per-file flags/paths seen while scanning one ``diff --git`` block."""
+
+    is_new: bool = False
+    is_deleted: bool = False
+    src_path: str | None = None
+    dst_path: str | None = None
+    started: bool = False
+
+    def reset(self) -> None:
+        """Begin a new file block, clearing all accumulated state."""
+        self.is_new = False
+        self.is_deleted = False
+        self.src_path = None
+        self.dst_path = None
+        self.started = True
+
+    def update(self, line: str) -> None:
+        """Update state from a single non-``diff --git`` header line."""
+        if line.startswith("new file mode"):
+            self.is_new = True
+        elif line.startswith("deleted file mode"):
+            self.is_deleted = True
+        elif line.startswith("--- "):
+            self.src_path = _path_after(line, "--- ", _SRC_PREFIX) or self.src_path
+        elif line.startswith("+++ "):
+            self.dst_path = _path_after(line, "+++ ", _DST_PREFIX) or self.dst_path
+
+    def entry(self) -> tuple[str, bool, bool] | None:
+        """Return the ``(rel_path, is_new, is_deleted)`` entry for this block, if a path was captured."""
+        rel = self.src_path if self.is_deleted else self.dst_path
+        return (rel, self.is_new, self.is_deleted) if rel else None
 
 
 class DiffMixin(GitContextBase):
@@ -80,45 +127,24 @@ class DiffMixin(GitContextBase):
         Returns:
             List of ``(rel_path, is_new, is_deleted)`` tuples, one per changed file.
         """
-        src_prefix = "upstream-template-old/"
-        dst_prefix = "upstream-template-new/"
-
         results: list[tuple[str, bool, bool]] = []
-        is_new = False
-        is_deleted = False
-        src_path: str | None = None
-        dst_path: str | None = None
-        in_diff = False
+        state = _DiffFileState()
 
         def _flush() -> None:
             """Emit the current file entry into results if a path was captured."""
-            rel = dst_path if not is_deleted else src_path
-            if rel:
-                results.append((rel, is_new, is_deleted))
+            entry = state.entry()
+            if entry:
+                results.append(entry)
 
         for line in diff.splitlines():
             if line.startswith("diff --git "):
-                if in_diff:
+                if state.started:
                     _flush()
-                is_new = False
-                is_deleted = False
-                src_path = None
-                dst_path = None
-                in_diff = True
-            elif line.startswith("new file mode"):
-                is_new = True
-            elif line.startswith("deleted file mode"):
-                is_deleted = True
-            elif line.startswith("--- "):
-                raw = line[4:].strip().strip('"').split("\t")[0]
-                if raw != "/dev/null" and raw.startswith(src_prefix):
-                    src_path = raw[len(src_prefix) :]
-            elif line.startswith("+++ "):
-                raw = line[4:].strip().strip('"').split("\t")[0]
-                if raw != "/dev/null" and raw.startswith(dst_prefix):
-                    dst_path = raw[len(dst_prefix) :]
+                state.reset()
+            else:
+                state.update(line)
 
-        if in_diff:
+        if state.started:
             _flush()
 
         return results

--- a/src/rhiza/models/_git/merge.py
+++ b/src/rhiza/models/_git/merge.py
@@ -3,6 +3,7 @@
 import shutil
 import subprocess  # nosec B404
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,8 +18,72 @@ if TYPE_CHECKING:
     from rhiza.models.template import RhizaTemplate
 
 
+@dataclass(frozen=True)
+class _MergePaths:
+    """The three on-disk locations for a single file in a 3-way merge."""
+
+    target: Path
+    upstream: Path
+    base: Path
+
+
 class MergeMixin(RemoteOpsMixin, DiffMixin):
     """Apply template changes to the target via a cruft-style 3-way merge."""
+
+    def _apply_non_merge(self, rel_path: str, paths: "_MergePaths", *, is_new: bool, is_deleted: bool) -> None:
+        """Handle the non-3-way cases: additions, deletions, and overwrite-from-upstream."""
+        if is_deleted:
+            if paths.target.exists():
+                paths.target.unlink()
+                logger.debug(f"[merge-file] Deleted: {rel_path}")
+            return
+
+        # New, missing-in-target, or no-base: just take upstream when it exists.
+        if paths.upstream.exists():
+            target_existed = paths.target.exists()
+            paths.target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(paths.upstream, paths.target)
+            if is_new:
+                logger.debug(f"[merge-file] Added: {rel_path}")
+            elif not target_existed:
+                logger.debug(f"[merge-file] Created (missing in target): {rel_path}")
+            else:
+                logger.debug(f"[merge-file] Overwrite (no base): {rel_path}")
+
+    def _git_merge_file(self, rel_path: str, paths: "_MergePaths") -> tuple[bool, bool]:
+        """Run ``git merge-file`` for one modified file.
+
+        Returns:
+            A ``(is_clean, is_conflict)`` tuple. ``is_clean`` is False on either
+            a conflict or a merge error; ``is_conflict`` is True only when
+            conflict markers were written and need manual resolution.
+        """
+        result = subprocess.run(  # nosec B603  # noqa: S603
+            [
+                self.executable,
+                "merge-file",
+                "-L",
+                "HEAD",
+                "-L",
+                "base",
+                "-L",
+                "rhiza-template",
+                str(paths.target),
+                str(paths.base),
+                str(paths.upstream),
+            ],
+            capture_output=True,
+            env=self.env,
+        )
+
+        if result.returncode > 0:
+            logger.warning(f"[merge-file] Conflict in {rel_path} — resolve markers manually")
+            return False, True
+        if result.returncode < 0:
+            logger.warning(f"[merge-file] Error merging {rel_path}: {result.stderr.decode().strip()}")
+            return False, False
+        logger.debug(f"[merge-file] Clean merge: {rel_path}")
+        return True, False
 
     def _merge_file_fallback(
         self,
@@ -50,65 +115,26 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
         conflict_files: list[str] = []
 
         for rel_path, is_new, is_deleted in file_entries:
-            target_file = target / rel_path
-            upstream_file = upstream_snapshot / rel_path
-            base_file = base_snapshot / rel_path
-
-            if is_new:
-                if upstream_file.exists():
-                    target_file.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(upstream_file, target_file)
-                    logger.debug(f"[merge-file] Added: {rel_path}")
-                continue
-
-            if is_deleted:
-                if target_file.exists():
-                    target_file.unlink()
-                    logger.debug(f"[merge-file] Deleted: {rel_path}")
-                continue
-
-            # Modified file — attempt a 3-way merge using the on-disk snapshots.
-            if not target_file.exists():
-                if upstream_file.exists():
-                    target_file.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(upstream_file, target_file)
-                    logger.debug(f"[merge-file] Created (missing in target): {rel_path}")
-                continue
-
-            if not base_file.exists() or not upstream_file.exists():
-                # Cannot 3-way-merge without both sides; just take upstream.
-                if upstream_file.exists():
-                    shutil.copy2(upstream_file, target_file)
-                    logger.debug(f"[merge-file] Overwrite (no base): {rel_path}")
-                continue
-
-            result = subprocess.run(  # nosec B603  # noqa: S603
-                [
-                    self.executable,
-                    "merge-file",
-                    "-L",
-                    "HEAD",
-                    "-L",
-                    "base",
-                    "-L",
-                    "rhiza-template",
-                    str(target_file),
-                    str(base_file),
-                    str(upstream_file),
-                ],
-                capture_output=True,
-                env=self.env,
+            paths = _MergePaths(
+                target=target / rel_path,
+                upstream=upstream_snapshot / rel_path,
+                base=base_snapshot / rel_path,
             )
 
-            if result.returncode > 0:
+            if (
+                is_new
+                or is_deleted
+                or not paths.target.exists()
+                or not (paths.base.exists() and paths.upstream.exists())
+            ):
+                self._apply_non_merge(rel_path, paths, is_new=is_new, is_deleted=is_deleted)
+                continue
+
+            is_clean, is_conflict = self._git_merge_file(rel_path, paths)
+            if not is_clean:
+                all_clean = False
+            if is_conflict:
                 conflict_files.append(rel_path)
-                all_clean = False
-                logger.warning(f"[merge-file] Conflict in {rel_path} — resolve markers manually")
-            elif result.returncode < 0:
-                logger.warning(f"[merge-file] Error merging {rel_path}: {result.stderr.decode().strip()}")
-                all_clean = False
-            else:
-                logger.debug(f"[merge-file] Clean merge: {rel_path}")
 
         if conflict_files:
             detail = "\n".join(f"  {f}" for f in conflict_files)
@@ -221,28 +247,30 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
 
             # Scan and report any conflict artifacts left behind so users know
             # exactly which files need attention.
-            rej_files, marker_files = self._scan_conflict_artifacts(target)
-            if rej_files:
-                rej_detail = "\n".join(
-                    f"  {f.removesuffix('.rej')}  (unresolved hunks saved to {f})" for f in rej_files
-                )
-                logger.warning(
-                    f"The following file(s) have unresolved hunks:\n{rej_detail}\n"
-                    "  Open each .rej file, manually apply the diff hunks to the source file,\n"
-                    "  then delete the .rej file before committing."
-                )
-            if marker_files:
-                marker_detail = "\n".join(f"  {f}" for f in marker_files)
-                logger.warning(
-                    f"The following file(s) contain conflict markers:\n{marker_detail}\n"
-                    "  Resolve each <<<<<<< / ======= / >>>>>>> block and remove the markers\n"
-                    "  before committing."
-                )
-            if not rej_files and not marker_files:
-                logger.warning("Some changes could not be applied cleanly — check the working tree for partial edits.")
+            self._report_conflict_artifacts(target)
             return False
         else:
             return True
+
+    def _report_conflict_artifacts(self, target: Path) -> None:
+        """Scan *target* and emit guidance for any ``.rej`` files or conflict markers left behind."""
+        rej_files, marker_files = self._scan_conflict_artifacts(target)
+        if rej_files:
+            rej_detail = "\n".join(f"  {f.removesuffix('.rej')}  (unresolved hunks saved to {f})" for f in rej_files)
+            logger.warning(
+                f"The following file(s) have unresolved hunks:\n{rej_detail}\n"
+                "  Open each .rej file, manually apply the diff hunks to the source file,\n"
+                "  then delete the .rej file before committing."
+            )
+        if marker_files:
+            marker_detail = "\n".join(f"  {f}" for f in marker_files)
+            logger.warning(
+                f"The following file(s) contain conflict markers:\n{marker_detail}\n"
+                "  Resolve each <<<<<<< / ======= / >>>>>>> block and remove the markers\n"
+                "  before committing."
+            )
+        if not rej_files and not marker_files:
+            logger.warning("Some changes could not be applied cleanly — check the working tree for partial edits.")
 
     def _copy_files_to_target(self, snapshot_dir: Path, target: Path, materialized: list[Path]) -> None:
         """Copy all materialized files from a snapshot into the target project.

--- a/src/rhiza/models/bundle.py
+++ b/src/rhiza/models/bundle.py
@@ -128,6 +128,33 @@ class RhizaBundles(YamlSerializable):
     bundles: dict[str, BundleDefinition] = field(default_factory=dict)
     profiles: dict[str, ProfileDefinition] = field(default_factory=dict)
 
+    @staticmethod
+    def _bundle_to_entry(bundle: BundleDefinition) -> dict[str, Any]:
+        """Serialise a single bundle definition into its config dict, omitting falsy fields."""
+        entry: dict[str, Any] = {"description": bundle.description}
+        if bundle.required:
+            entry["required"] = bundle.required
+        if bundle.standalone:
+            entry["standalone"] = bundle.standalone
+        if bundle.requires:
+            entry["requires"] = bundle.requires
+        if bundle.recommends:
+            entry["recommends"] = bundle.recommends
+        if bundle.files:
+            entry["files"] = [f.to_config_entry() for f in bundle.files]
+        if bundle.notes:
+            entry["notes"] = bundle.notes
+        return entry
+
+    @staticmethod
+    def _profile_to_entry(profile: ProfileDefinition) -> dict[str, Any]:
+        """Serialise a single profile definition into its config dict."""
+        entry: dict[str, Any] = {}
+        if profile.description:
+            entry["description"] = profile.description
+        entry["bundles"] = profile.bundles
+        return entry
+
     @property
     def config(self) -> dict[str, Any]:
         """Return the bundles' current state as a configuration dictionary."""
@@ -136,34 +163,10 @@ class RhizaBundles(YamlSerializable):
         if self.version is not None:
             config["version"] = self.version
 
-        bundles_dict: dict[str, Any] = {}
-        for name, bundle in self.bundles.items():
-            bundle_entry: dict[str, Any] = {"description": bundle.description}
-            if bundle.required:
-                bundle_entry["required"] = bundle.required
-            if bundle.standalone:
-                bundle_entry["standalone"] = bundle.standalone
-            if bundle.requires:
-                bundle_entry["requires"] = bundle.requires
-            if bundle.recommends:
-                bundle_entry["recommends"] = bundle.recommends
-            if bundle.files:
-                bundle_entry["files"] = [f.to_config_entry() for f in bundle.files]
-            if bundle.notes:
-                bundle_entry["notes"] = bundle.notes
-            bundles_dict[name] = bundle_entry
-
-        config["bundles"] = bundles_dict
+        config["bundles"] = {name: self._bundle_to_entry(bundle) for name, bundle in self.bundles.items()}
 
         if self.profiles:
-            profiles_dict: dict[str, Any] = {}
-            for name, profile in self.profiles.items():
-                profile_entry: dict[str, Any] = {}
-                if profile.description:
-                    profile_entry["description"] = profile.description
-                profile_entry["bundles"] = profile.bundles
-                profiles_dict[name] = profile_entry
-            config["profiles"] = profiles_dict
+            config["profiles"] = {name: self._profile_to_entry(profile) for name, profile in self.profiles.items()}
 
         return config
 
@@ -231,6 +234,50 @@ class RhizaBundles(YamlSerializable):
 
         return cls(version=version, bundles=bundles, profiles=profiles)
 
+    def _resolve_bundle_order(self, bundle_names: list[str], *, strict: bool) -> list[str]:
+        """Return *bundle_names* and their ``requires`` dependencies in topological order.
+
+        Args:
+            bundle_names: Bundle names to resolve.
+            strict: When True, raise ``ValueError`` for unknown bundles or
+                circular dependencies; when False, silently skip them.
+
+        Returns:
+            Dependency-first ordering of the resolved bundle names.
+
+        Raises:
+            ValueError: If ``strict`` and a bundle is missing or forms a cycle.
+        """
+        order: list[str] = []
+        resolved: set[str] = set()
+        resolving: set[str] = set()
+
+        def _collect(name: str) -> None:
+            """Recursively resolve a single bundle's dependencies in topological order."""
+            if name not in self.bundles:
+                if strict:
+                    msg = f"Bundle '{name}' does not exist"
+                    raise ValueError(msg)
+                return
+            if name in resolving:
+                if strict:
+                    msg = f"Circular dependency detected for bundle '{name}'"
+                    raise ValueError(msg)
+                return
+            if name in resolved:
+                return
+
+            resolving.add(name)
+            for dependency in self.bundles[name].requires:
+                _collect(dependency)
+            resolving.remove(name)
+            resolved.add(name)
+            order.append(name)
+
+        for name in bundle_names:
+            _collect(name)
+        return order
+
     def resolve_to_paths(self, bundle_names: list[str]) -> list[str]:
         """Convert bundle names to deduplicated file paths.
 
@@ -243,45 +290,22 @@ class RhizaBundles(YamlSerializable):
         Raises:
             ValueError: If a bundle doesn't exist or circular dependency detected.
         """
-        bundles: list[str] = []
-        resolved: set[str] = set()
-        resolving: set[str] = set()
         paths: list[str] = []
         seen: set[str] = set()
 
-        def _collect(bundle_name: str) -> None:
-            """Recursively resolve bundle dependencies in topological order."""
-            if bundle_name not in self.bundles:
-                msg = f"Bundle '{bundle_name}' does not exist"
-                raise ValueError(msg)
-            if bundle_name in resolving:
-                msg = f"Circular dependency detected for bundle '{bundle_name}'"
-                raise ValueError(msg)
-            if bundle_name in resolved:
-                return
+        def _add(path: str) -> None:
+            """Append a path once, tracking it in the dedup set."""
+            if path not in seen:
+                paths.append(path)
+                seen.add(path)
 
-            resolving.add(bundle_name)
-            for dependency in self.bundles[bundle_name].requires:
-                _collect(dependency)
-            resolving.remove(bundle_name)
-            resolved.add(bundle_name)
-            bundles.append(bundle_name)
-
-        for bundle_name in bundle_names:
-            _collect(bundle_name)
-
-        for bundle_name in bundles:
+        for bundle_name in self._resolve_bundle_order(bundle_names, strict=True):
             bundle = self.bundles[bundle_name]
             if bundle.files:
                 for entry in bundle.files:
-                    if entry.source not in seen:
-                        paths.append(entry.source)
-                        seen.add(entry.source)
+                    _add(entry.source)
             else:
-                dir_path = f"bundles/{bundle_name}/"
-                if dir_path not in seen:
-                    paths.append(dir_path)
-                    seen.add(dir_path)
+                _add(f"bundles/{bundle_name}/")
 
         return paths
 
@@ -301,25 +325,7 @@ class RhizaBundles(YamlSerializable):
         resolved = self.resolve_to_paths(bundle_names)
         resolved_set = set(resolved)
 
-        seen: set[str] = set()
-        bundle_order: list[str] = []
-        resolving: set[str] = set()
-
-        def _collect(name: str) -> None:
-            """Recursively collect bundle dependency order, skipping already-seen entries."""
-            if name not in self.bundles or name in resolving or name in seen:
-                return
-            resolving.add(name)
-            for dep in self.bundles[name].requires:
-                _collect(dep)
-            resolving.remove(name)
-            seen.add(name)
-            bundle_order.append(name)
-
-        for name in bundle_names:
-            _collect(name)
-
-        for bundle_name in bundle_order:
+        for bundle_name in self._resolve_bundle_order(bundle_names, strict=False):
             bundle = self.bundles[bundle_name]
             if bundle.files:
                 for entry in bundle.files:

--- a/tests/test_models/test_bundle_model.py
+++ b/tests/test_models/test_bundle_model.py
@@ -230,6 +230,26 @@ class TestResolveToPaths:
         assert result.count("Makefile") == 1
         assert result.count("pyproject.toml") == 1
 
+    def test_resolve_bundle_order_non_strict_skips_unknown_bundle(self):
+        """Non-strict resolution silently skips an unknown bundle instead of raising."""
+        bundles = self._make_bundles()
+        order = bundles._resolve_bundle_order(["core", "nonexistent-bundle"], strict=False)
+        assert order == ["core"]
+
+    def test_resolve_bundle_order_non_strict_skips_cycle(self):
+        """Non-strict resolution breaks a dependency cycle instead of raising."""
+        bundles = RhizaBundles.from_config(
+            {
+                "bundles": {
+                    "a": {"description": "A", "files": ["a.txt"], "requires": ["b"]},
+                    "b": {"description": "B", "files": ["b.txt"], "requires": ["a"]},
+                }
+            }
+        )
+        # Both bundles are still ordered; the cycle is broken rather than raised.
+        order = bundles._resolve_bundle_order(["a"], strict=False)
+        assert sorted(order) == ["a", "b"]
+
 
 # ---------------------------------------------------------------------------
 # ProfileDefinition and profiles support


### PR DESCRIPTION
Closes #557

## Summary

Reduces the cyclomatic complexity of the six functions in `src/` that exceeded ruff's `C901` threshold of 10. All changes are pure refactors (helper extraction) with no behaviour change:

| Function | Before | Change |
|---|---|---|
| `bundle.py::config` | 12 | extracted `_bundle_to_entry` / `_profile_to_entry` |
| `bundle.py::resolve_to_paths` | 12 | extracted shared `_resolve_bundle_order` (also de-dupes the near-identical resolver in `resolve_to_path_map`) |
| `_git/diff.py::_parse_diff_filenames` | 13 | moved per-line state into a `_DiffFileState` dataclass |
| `_git/merge.py::_merge_file_fallback` | 13 | extracted `_apply_non_merge` + `_git_merge_file` |
| `_git/merge.py::_apply_diff` | 11 | extracted `_report_conflict_artifacts` |
| `validate.py::_validate_configuration_mode` | 11 | extracted `_validate_profiles_field` |

Adds two unit tests for the non-strict branches of the new `_resolve_bundle_order`, keeping line coverage at 100%.

## Gate results

- `uv run ruff check src/ --select C901` — **0 errors** (was 6)
- `make fmt` — **PASS**
- `make typecheck` — **PASS** (ty + mypy --strict)
- `make test` — **PASS**, 648 passed, **100.00% coverage**
