### PR TITLE
chore: update rhiza to v1.0.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.0
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.0
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 3186f09ecffa95a44148fbae02bc90d9e9dd05e2
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.0
 include: []
 exclude:
 - bundles/github-tests/.github/workflows/rhiza_mutation.yml
@@ -107,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T17:55:15Z'
+synced_at: '2026-06-29T13:06:39Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.19.9"
+ref: "v1.0.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `ref` to `v1.0.0` in `.rhiza/template.yml`
- Platform profile: `github-project` (unchanged)
- Runs `make sync` to apply upstream template changes; no conflicts

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` | PASS |
| `make typecheck` (ty + mypy --strict) | PASS |
| `make docs-coverage` (interrogate 100%) | PASS |
| `make deptry` | PASS |
| `make security` (pip-audit + bandit) | PASS |
| `make validate` | PASS |
| `make test` (648 passed, 100% coverage) | PASS |

`make validate` (`.rhiza/tests`, 175 tests) and `make test` (`src/`, 648 tests) are disjoint suites — the v1.0.0 double-pytest behaviour does **not** apply to this repo.

## Scorecard — 9.9 / 10 (locally-owned scope)

| Subcategory | Score |
|---|---|
| Linting / style | 10 |
| Type safety | 10 |
| Test pass rate | 10 |
| Test coverage & depth | 10 |
| Documentation | 10 |
| Dependency & security hygiene | 10 |
| Code structure & readability | 9 |

**Highest-leverage improvement:** decompose the largest command module `src/rhiza/commands/init.py` (320 stmts). Optional — the module is cohesive and fully covered.

Note: the v1.0.0 mutation workflow now gates its enforce step behind `vars.MUTATION_ENABLED`, so the `exclude:` for `rhiza_mutation.yml` in `.rhiza/template.yml` may no longer be needed — left in place here; re-evaluate in a follow-up.
