### PR TITLE
Fix for Commented-out code

### DIFF
--- a/.rhiza/tests/structure/test_project_layout.py
+++ b/.rhiza/tests/structure/test_project_layout.py
@@ -22,7 +22,6 @@ class TestRootFixture:
     def test_root_contains_expected_directories(self, root):
         """Root should contain all expected project directories."""
         required_dirs = [".rhiza"]
-        # optional_dirs = ["src", "tests", "book"]  # src/ is optional (rhiza itself doesn't have one)
 
         for dirname in required_dirs:
             assert (root / dirname).exists(), f"Required directory {dirname} not found"
@@ -32,9 +31,7 @@ class TestRootFixture:
         if not any((root / ci_dir).exists() for ci_dir in ci_dirs):
             pytest.fail(f"At least one CI directory from {ci_dirs} must exist")
 
-        # for dirname in optional_dirs:
-        #     if not (root / dirname).exists():
-        #         pytest.skip(f"Optional directory {dirname} not present in this project")
+        # Optional directories are not enforced in this test.
 
     def test_root_contains_expected_files(self, root):
         """Root should contain all expected configuration files."""


### PR DESCRIPTION
The best fix is to remove the commented-out executable code and replace it with a short explanatory comment (or nothing) so behavior remains unchanged.

In `.rhiza/tests/structure/test_project_layout.py`, inside `test_root_contains_expected_directories`, remove:
- the commented `optional_dirs` assignment on line 25
- the commented loop on lines 35–37

Optionally keep a plain-language comment indicating optional directories are intentionally not enforced in this test. This preserves current functionality (no optional-dir checks are run) while eliminating commented-out code.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._