### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/rhiza/language_validators.py
+++ b/src/rhiza/language_validators.py
@@ -33,7 +33,7 @@ class LanguageValidator(ABC):
         Returns:
             Language name (e.g., "python", "go").
         """
-        ...
+        raise NotImplementedError
 
 
 class PythonValidator(LanguageValidator):


### PR DESCRIPTION
To fix this class of issue, replace no-op placeholder statements (`...`) used as method bodies with explicit `raise NotImplementedError` in abstract methods. This preserves behavior (abstract class contract remains unchanged), improves readability, and satisfies static analysis rules about ineffective statements.

Best fix for this file:
- In `src/rhiza/language_validators.py`, update `LanguageValidator.get_language_name` so the method body raises `NotImplementedError` instead of using `...`.
- No new imports, helper methods, or external dependencies are required.
- (Optional but recommended consistency: do the same for `validate_project_structure` too, since it currently also uses `...` and may be flagged similarly by the same rule.)


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._