### PR TITLE
test(init): cover reachability check's empty-stderr branch

### DIFF
--- a/tests/test_commands/test_init.py
+++ b/tests/test_commands/test_init.py
@@ -658,6 +658,17 @@ class TestCheckTemplateRepositoryReachable:
         assert result is False
 
     @patch("rhiza.commands.init.subprocess.run")
+    def test_unreachable_repository_with_empty_stderr_returns_false(self, mock_run):
+        """Test that a non-zero exit with no stderr still returns False.
+
+        Covers the branch where git ls-remote fails but emits no stderr, so the
+        function logs the "no stderr output" message rather than the stderr text.
+        """
+        mock_run.return_value = MagicMock(returncode=128, stderr=b"")
+        result = _check_template_repository_reachable("typo/nonexistent", "github")
+        assert result is False
+
+    @patch("rhiza.commands.init.subprocess.run")
     def test_gitlab_host_uses_gitlab_url(self, mock_run):
         """Test that gitlab host uses gitlab.com URL."""
         mock_run.return_value = MagicMock(returncode=0)


### PR DESCRIPTION
Closes #574.

## Why
`src/rhiza/commands/init.py:120` was the only uncovered line in the repo (99.96% → the last statement). It's the `else` branch of `_check_template_repository_reachable`, reached only when `git ls-remote` exits non-zero **and** emits no stderr:

```python
if stderr_output:
    logger.error(f"git ls-remote stderr: {stderr_output}")   # covered
else:
    logger.error("git ls-remote returned no stderr output.")  # line 120 — was uncovered
```

The existing `test_unreachable_repository_returns_false` used a bare `MagicMock(returncode=128)` whose auto-attribute `stderr` is truthy, so it always took the stderr-present branch.

## What
Adds `test_unreachable_repository_with_empty_stderr_returns_false`: mocks `subprocess.run` to return `returncode=128, stderr=b""` (decodes to an empty string → falsy → the `else` branch) and asserts the function still returns `False`.

## Verification
- `make test` ✅ — **651 passed**, `src/` line coverage now **100.00%** (`init.py` 197/197).
- `make fmt` ✅.

Pure test addition; no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
