### PR TITLE
refactor(models): break models→commands import cycle (#576)

### DIFF
--- a/src/rhiza/commands/_sync_helpers.py
+++ b/src/rhiza/commands/_sync_helpers.py
@@ -4,29 +4,43 @@ This module exposes the private implementation functions used by
 :mod:`rhiza.commands.sync`.  Placing them here gives tests a stable import
 path (``from rhiza.commands._sync_helpers import ...``) without coupling them
 to the command module's public API.
+
+The lock-file persistence and orphan-cleanup helpers actually live in
+:mod:`rhiza.models._git.lock_io` (the models layer drives them during the
+merge); they are re-exported here so existing
+``from rhiza.commands._sync_helpers import ...`` call sites keep working
+without creating a ``models -> commands`` import cycle.
 """
 
-import contextlib
-import dataclasses
-import os
 from pathlib import Path
-
-try:
-    import fcntl
-
-    _FCNTL_AVAILABLE = True
-except ImportError:  # pragma: no cover - Windows
-    _FCNTL_AVAILABLE = False
 
 from loguru import logger
 
 from rhiza.models import TemplateLock
+from rhiza.models._git.lock_io import (
+    _FCNTL_AVAILABLE,
+    LOCK_FILE,
+    _clean_orphaned_files,
+    _delete_orphaned_file,
+    _files_from_snapshot,
+    _lock_content_unchanged,
+    _read_previously_tracked_files,
+    _warn_about_workflow_files,
+    _write_lock,
+)
 
-# ---------------------------------------------------------------------------
-# Lock-file constant
-# ---------------------------------------------------------------------------
-
-LOCK_FILE = ".rhiza/template.lock"
+__all__ = [
+    "LOCK_FILE",
+    "_FCNTL_AVAILABLE",
+    "_clean_orphaned_files",
+    "_delete_orphaned_file",
+    "_files_from_snapshot",
+    "_load_lock_or_warn",
+    "_lock_content_unchanged",
+    "_read_previously_tracked_files",
+    "_warn_about_workflow_files",
+    "_write_lock",
+]
 
 
 # Shared template helpers
@@ -52,274 +66,3 @@ def _load_lock_or_warn(target: Path, lock_file: Path | None = None) -> TemplateL
         logger.warning("No template.lock found — run `rhiza sync` first")
         return None
     return TemplateLock.from_yaml(lock_path)
-
-
-def _warn_about_workflow_files(materialized_files: list[Path]) -> None:
-    """Warn if workflow files were materialized.
-
-    Args:
-        materialized_files: List of materialized file paths.
-    """
-    workflow_files = [p for p in materialized_files if p.parts[:2] == (".github", "workflows")]
-
-    if workflow_files:
-        logger.warning(
-            "Workflow files were materialized. Updating these files requires "
-            "a token with the 'workflow' permission in GitHub Actions."
-        )
-        logger.info(f"Workflow files affected: {len(workflow_files)}")
-
-
-def _files_from_snapshot(snapshot_dir: Path) -> set[Path]:
-    """Return all files in *snapshot_dir* as paths relative to that directory.
-
-    Args:
-        snapshot_dir: Root of a snapshot directory tree.
-
-    Returns:
-        Set of relative file paths found under *snapshot_dir*.
-    """
-    return {f.relative_to(snapshot_dir) for f in snapshot_dir.rglob("*") if f.is_file()}
-
-
-def _read_previously_tracked_files(
-    target: Path,
-    base_snapshot: Path | None = None,
-    lock_file: Path | None = None,
-) -> set[Path]:
-    """Return the set of files tracked by the last sync.
-
-    Resolution order:
-    1. ``template.lock.files`` when the field is present and non-empty.
-    2. *base_snapshot* directory listing when provided and non-empty (used as a
-       fallback for lock files that pre-date the ``files`` field).
-    3. Legacy ``.rhiza/history`` file for backward compatibility.
-
-    Args:
-        target: Target repository path.
-        base_snapshot: Optional directory containing the template snapshot at
-            the previously-synced SHA.  When the lock file has no ``files``
-            entry this snapshot is used to reconstruct the tracked-file list,
-            avoiding an extra network fetch.
-        lock_file: Optional explicit path to the lock file.  When ``None`` the
-            default ``<target>/.rhiza/template.lock`` is used.
-
-    Returns:
-        Set of previously tracked file paths (relative to target), or an empty
-        set when no tracking information is found.
-    """
-    if lock_file is None:
-        lock_file = target / ".rhiza" / "template.lock"
-    if lock_file.exists():
-        try:
-            lock = TemplateLock.from_yaml(lock_file)
-            if lock.files:
-                files = {Path(f) for f in lock.files}
-                logger.debug(f"Reading previous file list from template.lock ({len(files)} files)")
-                return files
-            # Lock exists but has no files list - try to reconstruct from the
-            # base snapshot that was already fetched during this sync run.
-            if base_snapshot is not None and base_snapshot.is_dir():
-                snapshot_files = _files_from_snapshot(base_snapshot)
-                if snapshot_files:
-                    logger.debug(f"Reconstructing previous file list from base snapshot ({len(snapshot_files)} files)")
-                    return snapshot_files
-        except Exception as e:  # noqa: BLE001  # best-effort lock read; any parse/IO error falls through to the history fallback below
-            logger.debug(f"Could not read template.lock for orphan cleanup: {e}")
-
-    history_file = target / ".rhiza" / "history"
-
-    if history_file.exists():
-        logger.debug(f"Reading existing history file: {history_file.relative_to(target)}")
-    else:
-        logger.debug("No previous file tracking found")
-        return set()
-
-    files = set()
-    with history_file.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith("#"):
-                files.add(Path(line))
-    return files
-
-
-def _delete_orphaned_file(target: Path, file_path: Path) -> None:
-    """Delete a single orphaned file from the target repository.
-
-    Args:
-        target: Target repository path.
-        file_path: Relative path of the orphaned file to delete.
-    """
-    full_path = target / file_path
-    if full_path.exists():
-        try:
-            full_path.unlink()
-            logger.success(f"[DEL] {file_path}")
-        except OSError as e:
-            logger.warning(f"Failed to delete {file_path}: {e}")
-    else:
-        logger.debug(f"Skipping {file_path} (already deleted)")
-
-
-def _clean_orphaned_files(
-    target: Path,
-    materialized_files: list[Path],
-    base_snapshot: Path | None = None,
-    excludes: set[str] | None = None,
-    previously_tracked_files: set[Path] | None = None,
-    lock_file: Path | None = None,
-) -> None:
-    """Clean up files that are no longer maintained by template.
-
-    Files that are explicitly excluded via the ``exclude:`` setting in
-    ``template.yml`` are never deleted even if they appear in a previous lock
-    but are absent from *materialized_files*.
-
-    Args:
-        target: Target repository path.
-        materialized_files: List of currently materialized files.
-        base_snapshot: Optional directory containing the template snapshot at
-            the previously-synced SHA.  Passed through to
-            :func:`_read_previously_tracked_files` as a fallback when the lock
-            file has no ``files`` entry.  Ignored when *previously_tracked_files*
-            is supplied directly.
-        excludes: Optional set of relative path strings that are currently
-            excluded from the template sync.  Any previously-tracked file
-            present in this set is kept (the user explicitly opted it out).
-        previously_tracked_files: Optional pre-read set of files that were
-            tracked by the previous sync.  When supplied this takes precedence
-            over reading from the on-disk lock file, which allows callers to
-            snapshot the old state before the lock is overwritten by the merge.
-        lock_file: Optional explicit path to the lock file.  When ``None`` the
-            default ``<target>/.rhiza/template.lock`` is used.
-    """
-    if previously_tracked_files is None:
-        previously_tracked_files = _read_previously_tracked_files(
-            target, base_snapshot=base_snapshot, lock_file=lock_file
-        )
-    if not previously_tracked_files:
-        return
-
-    logger.debug(f"Found {len(previously_tracked_files)} file(s) in previous tracking")
-
-    orphaned_files = previously_tracked_files - set(materialized_files)
-
-    # Don't delete files that the user has explicitly excluded — they have
-    # opted those files out of template management and want to keep them.
-    if excludes:
-        excluded_as_paths = {Path(e) for e in excludes}
-        orphaned_files = orphaned_files - excluded_as_paths
-
-    protected_files = {Path(".rhiza/template.yml")}
-
-    if not orphaned_files:
-        logger.debug("No orphaned files to clean up")
-        return
-
-    logger.info(f"Found {len(orphaned_files)} orphaned file(s) no longer maintained by template")
-    for file_path in sorted(orphaned_files):
-        if file_path in protected_files:
-            logger.info(f"Skipping protected file: {file_path}")
-            continue
-        _delete_orphaned_file(target, file_path)
-
-
-# ---------------------------------------------------------------------------
-# Lock-file helpers
-# ---------------------------------------------------------------------------
-
-
-def _lock_content_unchanged(lock: TemplateLock, lock_path: Path) -> bool:
-    """Return ``True`` when the on-disk lock is identical to *lock*, ignoring ``synced_at``.
-
-    Compares all fields except ``synced_at`` so that a re-sync that produces no
-    template changes does not cause a spurious timestamp-only update to
-    ``template.lock``.
-
-    Args:
-        lock: The candidate :class:`~rhiza.models.TemplateLock` to write.
-        lock_path: Path to the existing lock file on disk.
-
-    Returns:
-        ``True`` if the existing lock has the same effective content as *lock*,
-        ``False`` when the lock file does not exist or differs in any field
-        other than ``synced_at``.
-    """
-    if not lock_path.exists():
-        return False
-    try:
-        existing = TemplateLock.from_yaml(lock_path)
-    except Exception:  # noqa: BLE001  # any malformed/unreadable lock means "not equal" — a safe default
-        return False
-    return (
-        existing.sha == lock.sha
-        and existing.repo == lock.repo
-        and str(existing.host) == str(lock.host)
-        and existing.ref == lock.ref
-        and existing.include == lock.include
-        and existing.exclude == lock.exclude
-        and existing.templates == lock.templates
-        and existing.files == lock.files
-        and existing.strategy == lock.strategy
-    )
-
-
-def _write_lock(target: Path, lock: TemplateLock, lock_file: Path | None = None) -> None:
-    """Persist the lock data to the YAML lock file.
-
-    Writes to a ``.tmp`` sibling file first, then replaces the real lock file
-    atomically with ``os.replace()``.  An exclusive advisory lock (via
-    ``fcntl.flock``) is held for the entire write + rename sequence when
-    ``fcntl`` is available so that concurrent writers do not corrupt the file.
-    Falls back silently on platforms without ``fcntl`` (e.g. Windows).
-
-    Only files that actually exist in *target* are recorded in ``lock.files``.
-    This guarantees that the lock never references paths that are absent from
-    the repository.
-
-    The lock file is **not** rewritten when the effective content (all fields
-    except ``synced_at``) is identical to what is already on disk, preventing
-    spurious timestamp-only changes when no template updates are available.
-
-    Args:
-        target: Path to the target repository.
-        lock: The :class:`~rhiza.models.TemplateLock` to record.
-        lock_file: Optional explicit path for the lock file.  When ``None`` the
-            default ``<target>/.rhiza/template.lock`` is used.
-    """
-    # Filter the files list to only include paths that exist on disk so that
-    # the lock never contains entries for files that are absent from the repo.
-    # Always sort the resulting list alphabetically.
-    existing_files = sorted(f for f in lock.files if (target / f).exists())
-    missing = sorted(set(lock.files) - set(existing_files))
-    if missing:
-        missing_str = ", ".join(missing)
-        logger.warning(f"{len(missing)} file(s) in lock absent from target and excluded: {missing_str}")
-    lock = dataclasses.replace(lock, files=existing_files)
-
-    lock_path = lock_file if lock_file is not None else target / LOCK_FILE
-
-    # Skip write when only synced_at would change to avoid spurious diffs.
-    if _lock_content_unchanged(lock, lock_path):
-        logger.info(f"{lock_path.name} is already up to date — skipping write")
-        return
-
-    tmp_path = Path(str(lock_path) + ".tmp")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    # Acquire an exclusive advisory lock via a dedicated lock-fd file so that
-    # the flock survives the os.replace() rename of the actual lock file.
-    lock_fd_path = Path(str(lock_path) + ".fd")
-    try:
-        with lock_fd_path.open("a", encoding="utf-8") as lock_fd:
-            if _FCNTL_AVAILABLE:
-                fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            else:
-                logger.debug("fcntl not available - skipping advisory lock on write")
-            lock.to_yaml(tmp_path)
-            os.replace(tmp_path, lock_path)
-    finally:
-        # Best-effort cleanup of the fd file; failures here are non-critical.
-        with contextlib.suppress(OSError):
-            lock_fd_path.unlink(missing_ok=True)
-    logger.info(f"Updated {lock_path.name} -> {lock.sha[:12]}")

--- a/src/rhiza/models/_git/lock_io.py
+++ b/src/rhiza/models/_git/lock_io.py
@@ -1,0 +1,307 @@
+"""Lock-file persistence and orphan-cleanup for the 3-way merge.
+
+These helpers own reading/writing ``template.lock`` and reconciling the set of
+template-managed files on disk after a merge.  They live in the models layer
+because :mod:`rhiza.models._git.merge` drives them as part of the sync
+strategy; keeping them here avoids a ``models -> commands`` import cycle (see
+ADR-0005).  The ``rhiza.commands._sync_helpers`` module re-exports them so
+existing command-layer call sites keep working.
+"""
+
+import contextlib
+import dataclasses
+import os
+from pathlib import Path
+
+try:
+    import fcntl
+
+    _FCNTL_AVAILABLE = True
+except ImportError:  # pragma: no cover - Windows
+    _FCNTL_AVAILABLE = False
+
+from loguru import logger
+
+from rhiza.models.lock import TemplateLock
+
+# ---------------------------------------------------------------------------
+# Lock-file constant
+# ---------------------------------------------------------------------------
+
+LOCK_FILE = ".rhiza/template.lock"
+
+
+# ---------------------------------------------------------------------------
+# Orphan-cleanup helpers
+# ---------------------------------------------------------------------------
+
+
+def _warn_about_workflow_files(materialized_files: list[Path]) -> None:
+    """Warn if workflow files were materialized.
+
+    Args:
+        materialized_files: List of materialized file paths.
+    """
+    workflow_files = [p for p in materialized_files if p.parts[:2] == (".github", "workflows")]
+
+    if workflow_files:
+        logger.warning(
+            "Workflow files were materialized. Updating these files requires "
+            "a token with the 'workflow' permission in GitHub Actions."
+        )
+        logger.info(f"Workflow files affected: {len(workflow_files)}")
+
+
+def _files_from_snapshot(snapshot_dir: Path) -> set[Path]:
+    """Return all files in *snapshot_dir* as paths relative to that directory.
+
+    Args:
+        snapshot_dir: Root of a snapshot directory tree.
+
+    Returns:
+        Set of relative file paths found under *snapshot_dir*.
+    """
+    return {f.relative_to(snapshot_dir) for f in snapshot_dir.rglob("*") if f.is_file()}
+
+
+def _read_previously_tracked_files(
+    target: Path,
+    base_snapshot: Path | None = None,
+    lock_file: Path | None = None,
+) -> set[Path]:
+    """Return the set of files tracked by the last sync.
+
+    Resolution order:
+    1. ``template.lock.files`` when the field is present and non-empty.
+    2. *base_snapshot* directory listing when provided and non-empty (used as a
+       fallback for lock files that pre-date the ``files`` field).
+    3. Legacy ``.rhiza/history`` file for backward compatibility.
+
+    Args:
+        target: Target repository path.
+        base_snapshot: Optional directory containing the template snapshot at
+            the previously-synced SHA.  When the lock file has no ``files``
+            entry this snapshot is used to reconstruct the tracked-file list,
+            avoiding an extra network fetch.
+        lock_file: Optional explicit path to the lock file.  When ``None`` the
+            default ``<target>/.rhiza/template.lock`` is used.
+
+    Returns:
+        Set of previously tracked file paths (relative to target), or an empty
+        set when no tracking information is found.
+    """
+    if lock_file is None:
+        lock_file = target / ".rhiza" / "template.lock"
+    if lock_file.exists():
+        try:
+            lock = TemplateLock.from_yaml(lock_file)
+            if lock.files:
+                files = {Path(f) for f in lock.files}
+                logger.debug(f"Reading previous file list from template.lock ({len(files)} files)")
+                return files
+            # Lock exists but has no files list - try to reconstruct from the
+            # base snapshot that was already fetched during this sync run.
+            if base_snapshot is not None and base_snapshot.is_dir():
+                snapshot_files = _files_from_snapshot(base_snapshot)
+                if snapshot_files:
+                    logger.debug(f"Reconstructing previous file list from base snapshot ({len(snapshot_files)} files)")
+                    return snapshot_files
+        except Exception as e:  # noqa: BLE001  # best-effort lock read; any parse/IO error falls through to the history fallback below
+            logger.debug(f"Could not read template.lock for orphan cleanup: {e}")
+
+    history_file = target / ".rhiza" / "history"
+
+    if history_file.exists():
+        logger.debug(f"Reading existing history file: {history_file.relative_to(target)}")
+    else:
+        logger.debug("No previous file tracking found")
+        return set()
+
+    files = set()
+    with history_file.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                files.add(Path(line))
+    return files
+
+
+def _delete_orphaned_file(target: Path, file_path: Path) -> None:
+    """Delete a single orphaned file from the target repository.
+
+    Args:
+        target: Target repository path.
+        file_path: Relative path of the orphaned file to delete.
+    """
+    full_path = target / file_path
+    if full_path.exists():
+        try:
+            full_path.unlink()
+            logger.success(f"[DEL] {file_path}")
+        except OSError as e:
+            logger.warning(f"Failed to delete {file_path}: {e}")
+    else:
+        logger.debug(f"Skipping {file_path} (already deleted)")
+
+
+def _clean_orphaned_files(
+    target: Path,
+    materialized_files: list[Path],
+    base_snapshot: Path | None = None,
+    excludes: set[str] | None = None,
+    previously_tracked_files: set[Path] | None = None,
+    lock_file: Path | None = None,
+) -> None:
+    """Clean up files that are no longer maintained by template.
+
+    Files that are explicitly excluded via the ``exclude:`` setting in
+    ``template.yml`` are never deleted even if they appear in a previous lock
+    but are absent from *materialized_files*.
+
+    Args:
+        target: Target repository path.
+        materialized_files: List of currently materialized files.
+        base_snapshot: Optional directory containing the template snapshot at
+            the previously-synced SHA.  Passed through to
+            :func:`_read_previously_tracked_files` as a fallback when the lock
+            file has no ``files`` entry.  Ignored when *previously_tracked_files*
+            is supplied directly.
+        excludes: Optional set of relative path strings that are currently
+            excluded from the template sync.  Any previously-tracked file
+            present in this set is kept (the user explicitly opted it out).
+        previously_tracked_files: Optional pre-read set of files that were
+            tracked by the previous sync.  When supplied this takes precedence
+            over reading from the on-disk lock file, which allows callers to
+            snapshot the old state before the lock is overwritten by the merge.
+        lock_file: Optional explicit path to the lock file.  When ``None`` the
+            default ``<target>/.rhiza/template.lock`` is used.
+    """
+    if previously_tracked_files is None:
+        previously_tracked_files = _read_previously_tracked_files(
+            target, base_snapshot=base_snapshot, lock_file=lock_file
+        )
+    if not previously_tracked_files:
+        return
+
+    logger.debug(f"Found {len(previously_tracked_files)} file(s) in previous tracking")
+
+    orphaned_files = previously_tracked_files - set(materialized_files)
+
+    # Don't delete files that the user has explicitly excluded — they have
+    # opted those files out of template management and want to keep them.
+    if excludes:
+        excluded_as_paths = {Path(e) for e in excludes}
+        orphaned_files = orphaned_files - excluded_as_paths
+
+    protected_files = {Path(".rhiza/template.yml")}
+
+    if not orphaned_files:
+        logger.debug("No orphaned files to clean up")
+        return
+
+    logger.info(f"Found {len(orphaned_files)} orphaned file(s) no longer maintained by template")
+    for file_path in sorted(orphaned_files):
+        if file_path in protected_files:
+            logger.info(f"Skipping protected file: {file_path}")
+            continue
+        _delete_orphaned_file(target, file_path)
+
+
+# ---------------------------------------------------------------------------
+# Lock-file helpers
+# ---------------------------------------------------------------------------
+
+
+def _lock_content_unchanged(lock: TemplateLock, lock_path: Path) -> bool:
+    """Return ``True`` when the on-disk lock is identical to *lock*, ignoring ``synced_at``.
+
+    Compares all fields except ``synced_at`` so that a re-sync that produces no
+    template changes does not cause a spurious timestamp-only update to
+    ``template.lock``.
+
+    Args:
+        lock: The candidate :class:`~rhiza.models.TemplateLock` to write.
+        lock_path: Path to the existing lock file on disk.
+
+    Returns:
+        ``True`` if the existing lock has the same effective content as *lock*,
+        ``False`` when the lock file does not exist or differs in any field
+        other than ``synced_at``.
+    """
+    if not lock_path.exists():
+        return False
+    try:
+        existing = TemplateLock.from_yaml(lock_path)
+    except Exception:  # noqa: BLE001  # any malformed/unreadable lock means "not equal" — a safe default
+        return False
+    return (
+        existing.sha == lock.sha
+        and existing.repo == lock.repo
+        and str(existing.host) == str(lock.host)
+        and existing.ref == lock.ref
+        and existing.include == lock.include
+        and existing.exclude == lock.exclude
+        and existing.templates == lock.templates
+        and existing.files == lock.files
+        and existing.strategy == lock.strategy
+    )
+
+
+def _write_lock(target: Path, lock: TemplateLock, lock_file: Path | None = None) -> None:
+    """Persist the lock data to the YAML lock file.
+
+    Writes to a ``.tmp`` sibling file first, then replaces the real lock file
+    atomically with ``os.replace()``.  An exclusive advisory lock (via
+    ``fcntl.flock``) is held for the entire write + rename sequence when
+    ``fcntl`` is available so that concurrent writers do not corrupt the file.
+    Falls back silently on platforms without ``fcntl`` (e.g. Windows).
+
+    Only files that actually exist in *target* are recorded in ``lock.files``.
+    This guarantees that the lock never references paths that are absent from
+    the repository.
+
+    The lock file is **not** rewritten when the effective content (all fields
+    except ``synced_at``) is identical to what is already on disk, preventing
+    spurious timestamp-only changes when no template updates are available.
+
+    Args:
+        target: Path to the target repository.
+        lock: The :class:`~rhiza.models.TemplateLock` to record.
+        lock_file: Optional explicit path for the lock file.  When ``None`` the
+            default ``<target>/.rhiza/template.lock`` is used.
+    """
+    # Filter the files list to only include paths that exist on disk so that
+    # the lock never contains entries for files that are absent from the repo.
+    # Always sort the resulting list alphabetically.
+    existing_files = sorted(f for f in lock.files if (target / f).exists())
+    missing = sorted(set(lock.files) - set(existing_files))
+    if missing:
+        missing_str = ", ".join(missing)
+        logger.warning(f"{len(missing)} file(s) in lock absent from target and excluded: {missing_str}")
+    lock = dataclasses.replace(lock, files=existing_files)
+
+    lock_path = lock_file if lock_file is not None else target / LOCK_FILE
+
+    # Skip write when only synced_at would change to avoid spurious diffs.
+    if _lock_content_unchanged(lock, lock_path):
+        logger.info(f"{lock_path.name} is already up to date — skipping write")
+        return
+
+    tmp_path = Path(str(lock_path) + ".tmp")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # Acquire an exclusive advisory lock via a dedicated lock-fd file so that
+    # the flock survives the os.replace() rename of the actual lock file.
+    lock_fd_path = Path(str(lock_path) + ".fd")
+    try:
+        with lock_fd_path.open("a", encoding="utf-8") as lock_fd:
+            if _FCNTL_AVAILABLE:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            else:
+                logger.debug("fcntl not available - skipping advisory lock on write")
+            lock.to_yaml(tmp_path)
+            os.replace(tmp_path, lock_path)
+    finally:
+        # Best-effort cleanup of the fd file; failures here are non-critical.
+        with contextlib.suppress(OSError):
+            lock_fd_path.unlink(missing_ok=True)
+    logger.info(f"Updated {lock_path.name} -> {lock.sha[:12]}")

--- a/src/rhiza/models/_git/merge.py
+++ b/src/rhiza/models/_git/merge.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from rhiza.models._git import lock_io
 from rhiza.models._git.diff import DiffMixin
 from rhiza.models._git.remote import RemoteOpsMixin
 from rhiza.models._git.snapshot import _prepare_snapshot
@@ -323,18 +324,11 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
         Returns:
             True if all changes applied cleanly, False if any conflicts remain.
         """
-        from rhiza.commands._sync_helpers import (
-            _clean_orphaned_files,
-            _read_previously_tracked_files,
-            _warn_about_workflow_files,
-            _write_lock,
-        )
-
         # Snapshot the currently-tracked files before the merge runs.  The merge
         # may write a new lock (e.g. on the "template unchanged" early-return path
         # in _merge_with_base), so we must read the old state first to ensure
         # orphan cleanup compares against the previous sync, not the new one.
-        old_tracked_files = _read_previously_tracked_files(target, lock_file=lock_file)
+        old_tracked_files = lock_io._read_previously_tracked_files(target, lock_file=lock_file)
 
         base_snapshot = Path(tempfile.mkdtemp())
         clean = True
@@ -366,8 +360,8 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
                 logger.info(f"Restoring {len(missing_from_target)} template file(s) missing from target")
                 self._copy_files_to_target(upstream_snapshot, target, missing_from_target)
 
-            _warn_about_workflow_files(materialized)
-            _clean_orphaned_files(
+            lock_io._warn_about_workflow_files(materialized)
+            lock_io._clean_orphaned_files(
                 target,
                 materialized,
                 excludes=excludes,
@@ -375,7 +369,7 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
                 previously_tracked_files=old_tracked_files if old_tracked_files else None,
                 lock_file=lock_file,
             )
-            _write_lock(target, lock, lock_file=lock_file)
+            lock_io._write_lock(target, lock, lock_file=lock_file)
             logger.success(f"Sync complete — {len(materialized)} file(s) processed")
         finally:
             if base_snapshot.exists():
@@ -415,8 +409,6 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
         Returns:
             True if all changes applied cleanly, False if any conflicts remain.
         """
-        from rhiza.commands._sync_helpers import _write_lock
-
         logger.info(f"Cloning base snapshot at {base_sha[:12]}")
         base_clone = Path(tempfile.mkdtemp())
         try:
@@ -432,7 +424,7 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
 
         if not diff.strip():
             logger.success("Template unchanged since last sync — nothing to apply")
-            _write_lock(target, lock, lock_file=lock_file)
+            lock_io._write_lock(target, lock, lock_file=lock_file)
             return True
 
         logger.info("Applying template changes via 3-way merge (cruft)...")

--- a/tests/test_commands/test_init.py
+++ b/tests/test_commands/test_init.py
@@ -658,6 +658,17 @@ class TestCheckTemplateRepositoryReachable:
         assert result is False
 
     @patch("rhiza.commands.init.subprocess.run")
+    def test_unreachable_repository_with_empty_stderr_returns_false(self, mock_run):
+        """Test that a non-zero exit with no stderr still returns False.
+
+        Covers the branch where git ls-remote fails but emits no stderr, so the
+        function logs the "no stderr output" message rather than the stderr text.
+        """
+        mock_run.return_value = MagicMock(returncode=128, stderr=b"")
+        result = _check_template_repository_reachable("typo/nonexistent", "github")
+        assert result is False
+
+    @patch("rhiza.commands.init.subprocess.run")
     def test_gitlab_host_uses_gitlab_url(self, mock_run):
         """Test that gitlab host uses gitlab.com URL."""
         mock_run.return_value = MagicMock(returncode=0)

--- a/tests/test_commands/test_sync.py
+++ b/tests/test_commands/test_sync.py
@@ -187,7 +187,7 @@ class TestLockFile:
 
     def test_write_lock_without_fcntl(self, tmp_path):
         """_write_lock logs debug when fcntl is not available."""
-        with patch("rhiza.commands._sync_helpers._FCNTL_AVAILABLE", False):
+        with patch("rhiza.models._git.lock_io._FCNTL_AVAILABLE", False):
             _write_lock(tmp_path, TemplateLock(sha="cafebabe12345678"))
 
         assert TemplateLock.from_yaml(tmp_path / ".rhiza" / "template.lock").config["sha"] == "cafebabe12345678"
@@ -1481,7 +1481,7 @@ class TestThreeWayMergeSyncMergeStrategy:
         return project
 
     @patch("rhiza.models._git_utils.GitContext.clone_at_sha")
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_sync_merge_subsequent_applies_diff(
         self,
         mock_warn,
@@ -1531,7 +1531,7 @@ class TestThreeWayMergeSyncMergeStrategy:
         assert TemplateLock.from_yaml(target / ".rhiza" / "template.lock").config["sha"] == "upstream_sha_456"
 
     @patch("rhiza.models._git_utils.GitContext.clone_at_sha")
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_sync_merge_first_run_copies_without_merge(
         self,
         mock_warn,
@@ -1568,7 +1568,7 @@ class TestThreeWayMergeSyncMergeStrategy:
         mock_clone.assert_not_called()
 
     @patch("rhiza.models._git_utils.GitContext.clone_at_sha")
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_sync_merge_restores_files_missing_from_target(
         self,
         mock_warn,
@@ -1696,13 +1696,13 @@ class TestWarnAboutWorkflowFiles:
 
     def test_no_warning_without_workflow_files(self):
         """No warning is emitted when there are no workflow files."""
-        with patch("rhiza.commands._sync_helpers.logger") as mock_logger:
+        with patch("rhiza.models._git.lock_io.logger") as mock_logger:
             _warn_about_workflow_files([Path("Makefile"), Path(".github/CODEOWNERS")])
         mock_logger.warning.assert_not_called()
 
     def test_warning_with_workflow_files(self):
         """A warning is emitted when workflow files are present."""
-        with patch("rhiza.commands._sync_helpers.logger") as mock_logger:
+        with patch("rhiza.models._git.lock_io.logger") as mock_logger:
             _warn_about_workflow_files([Path(".github/workflows/ci.yml")])
         mock_logger.warning.assert_called_once()
         assert "workflow" in mock_logger.warning.call_args[0][0].lower()
@@ -1895,7 +1895,7 @@ class TestCleanOrphanedFiles:
         history_file.write_text("Makefile\n")
 
         # Force TemplateLock.from_yaml to raise
-        with patch("rhiza.commands._sync_helpers.TemplateLock.from_yaml", side_effect=Exception("corrupt lock")):
+        with patch("rhiza.models._git.lock_io.TemplateLock.from_yaml", side_effect=Exception("corrupt lock")):
             files = _read_previously_tracked_files(tmp_path)
 
         assert Path("Makefile") in files

--- a/tests/test_commands/test_sync_e2e.py
+++ b/tests/test_commands/test_sync_e2e.py
@@ -149,7 +149,7 @@ class TestSyncE2ETypicalWorkflow:
         assert "version = 1" in (project / "config.py").read_text()
         assert TemplateLock.from_yaml(project / ".rhiza" / "template.lock").config["sha"] == "sha_v1"
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_subsequent_sync_applies_template_changes(self, mock_warn, project, git_ctx, tmp_path):
         """After first sync, a second sync applies upstream changes and removes orphaned files.
 
@@ -254,7 +254,7 @@ class TestSyncE2ETypicalWorkflow:
 class TestSyncE2EOrphanedFiles:
     """End-to-end tests verifying orphaned-file removal when the template changes."""
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_orphaned_files_removed_when_template_removes_a_file(self, mock_warn, project, git_ctx, tmp_path):
         """Files tracked in the previous lock but absent from the new template are deleted.
 
@@ -322,7 +322,7 @@ class TestSyncE2EOrphanedFiles:
 class TestSyncE2EThreeWayMerge:
     """End-to-end tests verifying that local user changes survive a sync."""
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_user_changes_not_overwritten_by_sync(self, mock_warn, project, git_ctx, tmp_path):
         """Local modifications to a file are preserved when the template also changes it.
 
@@ -392,7 +392,7 @@ class TestSyncE2EThreeWayMerge:
 class TestSyncE2EExcludedFiles:
     """End-to-end tests verifying that excluded files are never removed."""
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_local_only_file_not_removed_when_not_tracked(self, mock_warn, project, git_ctx, tmp_path):
         """A file that was never tracked by the template is never deleted by sync.
 
@@ -420,7 +420,7 @@ class TestSyncE2EExcludedFiles:
 
         assert (project / "secrets.env").exists(), "local-only file must never be deleted by sync"
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_previously_tracked_file_excluded_is_not_removed(self, mock_warn, project, git_ctx, tmp_path):
         """A file that was synced before but is now excluded must not be deleted.
 
@@ -501,7 +501,7 @@ class TestSyncE2EUpdatedTemplateYml:
     base snapshot is populated correctly without a real git clone.
     """
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_adding_include_entry_syncs_new_file(self, mock_warn, project, git_ctx, tmp_path):
         """Adding a path to include: in template.yml causes the file to appear after the next sync.
 
@@ -581,7 +581,7 @@ class TestSyncE2EUpdatedTemplateYml:
         assert (project / "file_c.txt").exists(), "file_c.txt must be added after it is included in template.yml"
         assert TemplateLock.from_yaml(project / ".rhiza" / "template.lock").config["sha"] == "sha_v2"
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_removing_include_entry_removes_orphaned_file(self, mock_warn, project, git_ctx, tmp_path):
         """Removing a path from include: in template.yml causes it to be deleted on the next sync.
 
@@ -675,7 +675,7 @@ class TestSyncE2ECustomPaths:
     option.  Both files are always expected to live in the same directory.
     """
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_custom_path_reads_template_and_writes_lock(self, mock_warn, project, git_ctx, tmp_path):
         """Both template.yml and template.lock are resolved from the custom path.
 
@@ -716,7 +716,7 @@ class TestSyncE2ECustomPaths:
         # Default .rhiza/template.lock must NOT have been created.
         assert not (project / ".rhiza" / "template.lock").exists()
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_path_to_template_dot_uses_project_root(self, mock_warn, project, git_ctx, tmp_path):
         """``--path-to-template .`` places template.yml and template.lock in the project root.
 
@@ -753,7 +753,7 @@ class TestSyncE2ECustomPaths:
         assert TemplateLock.from_yaml(project / "template.lock").config["sha"] == "sha_root"
         assert not (project / ".rhiza" / "template.lock").exists()
 
-    @patch("rhiza.commands._sync_helpers._warn_about_workflow_files")
+    @patch("rhiza.models._git.lock_io._warn_about_workflow_files")
     def test_subsequent_sync_reads_custom_path_lock(self, mock_warn, project, git_ctx, tmp_path):
         """A second sync with a custom path correctly reads the previous SHA.
 


### PR DESCRIPTION
Closes #576.

## Problem
`src/rhiza/models/_git/merge.py` reached **up** into the commands layer via **function-local** imports, while `commands/_sync_helpers.py` imported back down into `models` — a genuine import cycle. The imports were function-local precisely because a module-level import would deadlock at load time.

- `models/_git/merge.py:326` / `:418` — `from rhiza.commands._sync_helpers import _write_lock, …`
- `commands/_sync_helpers.py` — `from rhiza.models import TemplateLock`

This violated layering direction (the lower `models/` layer must not depend on the upper `commands/` layer).

## Fix
Move the lock-file persistence and orphan-cleanup helpers **down into the models layer**, where the 3-way merge strategy actually drives them.

- **New `src/rhiza/models/_git/lock_io.py`** owns `LOCK_FILE`, `_write_lock`, `_lock_content_unchanged`, `_read_previously_tracked_files`, `_clean_orphaned_files`, `_delete_orphaned_file`, `_files_from_snapshot`, `_warn_about_workflow_files`, and the `fcntl`/`_FCNTL_AVAILABLE` block.
- **`merge.py`** imports `lock_io` at module level and calls `lock_io.<fn>(...)`; both function-local imports are removed.
- **`_sync_helpers.py`** is reduced to a re-export shim (317→13 stmts): it keeps the command-only `_load_lock_or_warn` and re-exports the moved names so existing `from rhiza.commands._sync_helpers import ...` call sites (`tree.py`, `status.py`, tests) keep working unchanged. Dependency direction is now `commands → models`.
- **Tests**: patch targets for the moved symbols now point at `rhiza.models._git.lock_io`.

No cycle risk in the new module: `lock_io → models.lock → _git.helpers`/`template` (all leaves), and `lock.py` already imported `_git.helpers`, so this direction was already established.

## Acceptance criteria (from #576)
- ✅ No `from rhiza.commands` import anywhere under `src/rhiza/models/`.
- ✅ No function-local imports remain in `merge.py`; the relevant imports are module-level.
- ✅ Gates green: `make fmt`, `make typecheck` (`ty` + `mypy --strict`, 35 files), `make test` — **649 passed, 100.00% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)