### PR TITLE
fix(bundle): reject path-traversal in bundle path remapping (#579)

### DIFF
--- a/src/rhiza/models/bundle.py
+++ b/src/rhiza/models/bundle.py
@@ -1,10 +1,39 @@
 """Bundle models for Rhiza configuration."""
 
 from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 from typing import Any
 
 from rhiza.models._base import YamlSerializable
 from rhiza.models._git.helpers import _normalize_to_list
+
+
+def _ensure_safe_bundle_path(value: str) -> None:
+    """Reject a bundle path that could escape the project directory.
+
+    ``template.yml`` is effectively untrusted input (it is fetched from the
+    template repository), and a remapped ``dest`` is joined onto the target
+    directory to decide where a file is written.  An absolute path, a Windows
+    drive letter, or a ``..`` traversal component could therefore write outside
+    the project.  This validates both ``source`` and ``dest`` at the trust
+    boundary so no such path can reach the materialize step.
+
+    Args:
+        value: A ``source`` or ``dest`` path from bundle config.
+
+    Raises:
+        ValueError: If *value* is absolute, uses a drive letter, or contains a
+            ``..`` traversal component.
+    """
+    # Normalise separators so a Windows-style path cannot slip past the checks.
+    normalized = value.replace("\\", "/")
+    pure = PurePosixPath(normalized)
+    has_drive = len(normalized) >= 2 and normalized[0].isalpha() and normalized[1] == ":"
+    if pure.is_absolute() or has_drive or ".." in pure.parts:
+        raise ValueError(  # noqa: TRY003
+            f"Unsafe bundle path {value!r}: paths must be relative to the project "
+            "root (no absolute paths, drive letters, or '..' traversal)."
+        )
 
 
 @dataclass(frozen=True)
@@ -21,6 +50,11 @@ class BundleFileEntry:
 
     source: str
     dest: str
+
+    def __post_init__(self) -> None:
+        """Validate that both paths stay within the project (no escape)."""
+        _ensure_safe_bundle_path(self.source)
+        _ensure_safe_bundle_path(self.dest)
 
     @property
     def is_remapped(self) -> bool:

--- a/tests/test_models/test_bundle_model.py
+++ b/tests/test_models/test_bundle_model.py
@@ -528,6 +528,58 @@ class TestBundleFileEntry:
         with pytest.raises(TypeError, match="source"):
             BundleFileEntry.from_config_entry({"dest": "Makefile"})
 
+    def test_dict_entry_unsafe_dest_rejected(self):
+        """A remapped dest that escapes the project directory is rejected."""
+        import pytest
+
+        from rhiza.models.bundle import BundleFileEntry
+
+        unsafe_dests = [
+            "../escape.txt",
+            "../../etc/passwd",
+            "nested/../../escape.txt",
+            "/etc/passwd",
+            "C:/Windows/system32/evil.txt",
+            "..\\escape.txt",
+        ]
+        for dest in unsafe_dests:
+            with pytest.raises(ValueError, match="Unsafe bundle path"):
+                BundleFileEntry.from_config_entry({"source": ".rhiza/stubs/ci.yml", "dest": dest})
+
+    def test_dict_entry_unsafe_source_rejected(self):
+        """A source that escapes the template clone is rejected."""
+        import pytest
+
+        from rhiza.models.bundle import BundleFileEntry
+
+        with pytest.raises(ValueError, match="Unsafe bundle path"):
+            BundleFileEntry.from_config_entry({"source": "../../etc/passwd", "dest": "config.py"})
+
+    def test_direct_construction_unsafe_dest_rejected(self):
+        """__post_init__ guards direct construction, not just from_config_entry."""
+        import pytest
+
+        from rhiza.models.bundle import BundleFileEntry
+
+        with pytest.raises(ValueError, match="Unsafe bundle path"):
+            BundleFileEntry(source="Makefile", dest="../../escape")
+
+    def test_resolve_to_path_map_rejects_malicious_remap(self):
+        """A malicious remap in template config is rejected when the bundles load."""
+        import pytest
+
+        from rhiza.models.bundle import RhizaBundles
+
+        malicious = {
+            "bundles": {
+                "evil": {
+                    "files": [{"source": ".rhiza/stubs/ci.yml", "dest": "../../../etc/cron.d/pwn"}],
+                }
+            }
+        }
+        with pytest.raises(ValueError, match="Unsafe bundle path"):
+            RhizaBundles.from_config(malicious)
+
     def test_to_config_entry_plain_string_roundtrip(self):
         """Non-remapped entry serialises back to a plain string."""
         from rhiza.models.bundle import BundleFileEntry

--- a/tests/test_models/test_models_comprehensive.py
+++ b/tests/test_models/test_models_comprehensive.py
@@ -34,6 +34,18 @@ _text = st.text(alphabet=_safe_alpha, min_size=0, max_size=40)
 _nonempty = st.text(alphabet=_safe_alpha, min_size=1, max_size=40)
 _path_list = st.lists(_nonempty, max_size=6)
 
+# Bundle file entries are validated by BundleFileEntry, which rejects absolute
+# paths, drive letters, and '..' traversal (path-traversal hardening, #579).
+# Build safe relative paths from slash-free segments so the generator honours
+# that invariant instead of producing values the model must reject.
+_path_segment = st.text(
+    alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_"),
+    min_size=1,
+    max_size=12,
+)
+_safe_rel_path = st.lists(_path_segment, min_size=1, max_size=3).map("/".join)
+_safe_path_list = st.lists(_safe_rel_path, max_size=6)
+
 # ============================================================================
 # TemplateLock
 # ============================================================================
@@ -435,7 +447,7 @@ class TestRhizaTemplateHypothesis:
 _bundle_def_st = st.builds(
     dict,
     description=_text,
-    files=st.one_of(st.none(), _path_list),
+    files=st.one_of(st.none(), _safe_path_list),
     workflows=st.one_of(st.none(), _path_list),
 )
 


### PR DESCRIPTION
Closes #579.

## Problem
`template.yml` is effectively untrusted input — it is fetched from the template repository. A bundle file entry can remap `source → dest`, and that `dest` is joined onto the target directory to decide where a file is written:

```python
# models/_git/snapshot.py
rel_dest = _remap_path(rel_source, effective_map)
dst = snapshot_dir / rel_dest          # <- absolute or '..' dest escapes here
shutil.copy2(f, dst)
```

An absolute path (`/etc/...`), a Windows drive letter (`C:/...`), or a `..` traversal component in `dest` could therefore write **outside** the project directory. `include` paths can't inject this (they're constrained by `f.relative_to(clone_dir)` over the clone glob), so the remap `dest` is the only untrusted write target — and it wasn't validated.

## Fix
Validate both `source` and `dest` at the **trust boundary** — when config is deserialized into `BundleFileEntry` — via `__post_init__`, so no unsafe path can reach the materialize step (`resolve_to_path_map` → `_prepare_snapshot`). Using `__post_init__` (rather than only `from_config_entry`) guards **every** construction path.

```python
def _ensure_safe_bundle_path(value: str) -> None:
    normalized = value.replace("\\", "/")
    pure = PurePosixPath(normalized)
    has_drive = len(normalized) >= 2 and normalized[0].isalpha() and normalized[1] == ":"
    if pure.is_absolute() or has_drive or ".." in pure.parts:
        raise ValueError(f"Unsafe bundle path {value!r}: ...")
```

## Tests
- `..`, `../../etc/passwd`, `nested/../../escape`, absolute (`/etc/passwd`), drive-letter (`C:/...`), and backslash (`..\escape`) destinations are all rejected.
- An unsafe `source` is rejected.
- Direct `BundleFileEntry(...)` construction is guarded (not just `from_config_entry`).
- `RhizaBundles.from_config({... malicious remap ...})` is rejected **end-to-end**.

## Done when (from #579)
- ✅ A test proves a `path_map` dest escaping the target directory (via `..` or absolute path) is rejected with a clear `ValueError`.
- ✅ Gates green: `fmt`, `typecheck` (`ty` + `mypy --strict`), `deptry`, `security` (bandit + pip-audit), `validate`, `test` — **652 passed; `bundle.py` 100% covered**.

> Note: the one uncovered line reported by `make test` (`init.py:120`, the empty-stderr branch of the reachability check) is a **pre-existing** gap on `main`, unrelated to this change — it's addressed separately by the `cover-reachability-empty-stderr` branch. This PR does not touch `init.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)