### PR TITLE
quality: address #591 (complexity) and #592 (failure-path tests)

### DIFF
--- a/src/rhiza/commands/init.py
+++ b/src/rhiza/commands/init.py
@@ -131,6 +131,30 @@ def _check_template_repository_reachable(template_repository: str, git_host: Git
         return True  # Don't block init if git is unavailable
 
 
+def _parse_version_tags(ls_remote_stdout: str) -> list[str]:
+    """Extract version tag names from ``git ls-remote --tags`` output.
+
+    Skips dereferenced annotated-tag objects (``^{}`` lines) and keeps only
+    refs under ``refs/tags/`` whose names look like versions (``vN.N`` / ``N.N``).
+
+    Args:
+        ls_remote_stdout: Raw stdout from ``git ls-remote --tags``.
+
+    Returns:
+        The list of matching version tag names (unsorted).
+    """
+    version_tags: list[str] = []
+    for line in ls_remote_stdout.splitlines():
+        if "^{}" in line:  # skip dereferenced annotated-tag objects
+            continue
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1].startswith("refs/tags/"):
+            tag = parts[1][len("refs/tags/") :]
+            if re.match(r"^v?\d+\.\d+", tag):
+                version_tags.append(tag)
+    return version_tags
+
+
 def _get_latest_tag(template_repository: str, git_host: GitHost | str = GitHost.GITHUB) -> str | None:
     """Fetch the latest version tag from the template repository via git ls-remote.
 
@@ -161,16 +185,7 @@ def _get_latest_tag(template_repository: str, git_host: GitHost | str = GitHost.
             logger.debug(f"git ls-remote --tags failed for {repo_url}")
             return None
 
-        version_tags = []
-        for line in result.stdout.splitlines():
-            if "^{}" in line:  # skip dereferenced annotated-tag objects
-                continue
-            parts = line.split("\t")
-            if len(parts) == 2 and parts[1].startswith("refs/tags/"):
-                tag = parts[1][len("refs/tags/") :]
-                if re.match(r"^v?\d+\.\d+", tag):
-                    version_tags.append(tag)
-
+        version_tags = _parse_version_tags(result.stdout)
         if not version_tags:
             logger.debug(f"No version tags found in {repo_url}")
             return None
@@ -421,8 +436,44 @@ def init(
     _create_template_file(target, git_host, language, template_repository, template_branch, template_file)
 
     # Bootstrap project structure based on language
+    _bootstrap_project_structure(
+        target,
+        language,
+        project_name=project_name,
+        package_name=package_name,
+        with_dev_dependencies=with_dev_dependencies,
+        git_host=git_host,
+    )
+
+    # Validate the template file
+    logger.debug("Validating template configuration")
+    return validate(target, template_file=template_file)
+
+
+def _bootstrap_project_structure(
+    target: Path,
+    language: str,
+    *,
+    project_name: str | None,
+    package_name: str | None,
+    with_dev_dependencies: bool,
+    git_host: GitHost | None,
+) -> None:
+    """Create the language-specific project scaffolding under *target*.
+
+    Python projects get the full package layout (package, ``pyproject.toml``,
+    ``uv.lock``, Makefile, mkdocs, README); Go and unknown languages get only a
+    README (Go additionally logs the ``go mod init`` hint).
+
+    Args:
+        target: Repository root directory.
+        language: Project language (``python``, ``go``, or other).
+        project_name: Custom project name; defaults to the target directory name.
+        package_name: Custom package name; defaults to the normalized project name.
+        with_dev_dependencies: Include development dependencies in ``pyproject.toml``.
+        git_host: Resolved Git hosting platform, used for mkdocs generation.
+    """
     if language == "python":
-        # Python-specific setup
         if project_name is None:
             project_name = target.name
         if package_name is None:
@@ -446,7 +497,3 @@ def init(
         # Unknown language - just create README
         logger.warning(f"Unknown language '{language}', creating minimal structure")
         _create_readme(target)
-
-    # Validate the template file
-    logger.debug("Validating template configuration")
-    return validate(target, template_file=template_file)

--- a/src/rhiza/commands/summarise/_render.py
+++ b/src/rhiza/commands/summarise/_render.py
@@ -210,12 +210,7 @@ def _generate_plain_output(
     """
     lines: list[str] = []
 
-    if options.include_header:
-        heading = options.title or "Template Synchronization"
-        lines.extend([heading, "=" * len(heading), ""])
-        if tmpl.repo:
-            lines.append(f"Template: {tmpl.repo}@{tmpl.branch}")
-            lines.append("")
+    _plain_header(lines, tmpl, options)
 
     total = sum(len(v) for v in changes.values())
     if not total:
@@ -229,6 +224,43 @@ def _generate_plain_output(
     )
     lines.append("")
 
+    _plain_change_body(lines, changes, categories, options)
+    _plain_footer(lines, tmpl, options)
+
+    return "\n".join(lines)
+
+
+def _plain_header(lines: list[str], tmpl: _TemplateInfo, options: SummariseOptions) -> None:
+    """Append the plain-text header (title + template line) to *lines*.
+
+    Args:
+        lines: Output line accumulator, mutated in place.
+        tmpl: Template metadata container.
+        options: Output customisation options.
+    """
+    if not options.include_header:
+        return
+    heading = options.title or "Template Synchronization"
+    lines.extend([heading, "=" * len(heading), ""])
+    if tmpl.repo:
+        lines.append(f"Template: {tmpl.repo}@{tmpl.branch}")
+        lines.append("")
+
+
+def _plain_change_body(
+    lines: list[str],
+    changes: dict[str, list[str]],
+    categories: dict[str, list[str]],
+    options: SummariseOptions,
+) -> None:
+    """Append the per-category or per-change-type file listing to *lines*.
+
+    Args:
+        lines: Output line accumulator, mutated in place.
+        changes: Dictionary of changes by type.
+        categories: Files grouped by category.
+        options: Output customisation options.
+    """
     if options.include_categories:
         for category, files in sorted(categories.items()):
             lines.append(f"{category}:")
@@ -242,12 +274,20 @@ def _generate_plain_output(
         ]:
             _plain_file_section(lines, label, files)
 
-    if options.include_footer:
-        if tmpl.last_sync:
-            lines.append(f"Last sync: {tmpl.last_sync}")
-        lines.append(f"Sync date: {datetime.now().astimezone().isoformat()}")
 
-    return "\n".join(lines)
+def _plain_footer(lines: list[str], tmpl: _TemplateInfo, options: SummariseOptions) -> None:
+    """Append the plain-text footer (last-sync + sync-date) to *lines*.
+
+    Args:
+        lines: Output line accumulator, mutated in place.
+        tmpl: Template metadata container.
+        options: Output customisation options.
+    """
+    if not options.include_footer:
+        return
+    if tmpl.last_sync:
+        lines.append(f"Last sync: {tmpl.last_sync}")
+    lines.append(f"Sync date: {datetime.now().astimezone().isoformat()}")
 
 
 def _generate_jinja2_output(template_path: Path, context: dict[str, Any]) -> str:

--- a/src/rhiza/commands/validate.py
+++ b/src/rhiza/commands/validate.py
@@ -184,7 +184,25 @@ def _validate_configuration_mode(config: dict[str, Any]) -> bool:
         logger.error("  • Hybrid: specify both templates and include")
         return False
 
-    # Log what mode is being used
+    _log_configuration_mode(config, has_profiles=has_profiles, has_templates=has_templates, has_include=has_include)
+    return True
+
+
+def _log_configuration_mode(
+    config: dict[str, Any],
+    *,
+    has_profiles: bool,
+    has_templates: bool,
+    has_include: bool,
+) -> None:
+    """Log which configuration mode the validated config is using.
+
+    Args:
+        config: Configuration dictionary (read for the ``profiles`` value).
+        has_profiles: Whether a valid ``profiles`` field is present.
+        has_templates: Whether a non-empty ``templates`` field is present.
+        has_include: Whether a non-empty ``include`` field is present.
+    """
     if has_profiles:
         logger.success(f"Using profile mode (profiles: {config['profiles']})")
     elif has_templates and has_include:
@@ -193,8 +211,6 @@ def _validate_configuration_mode(config: dict[str, Any]) -> bool:
         logger.success("Using template-based mode")
     else:
         logger.success("Using path-based mode")
-
-    return True
 
 
 def _validate_templates(config: dict[str, Any]) -> bool:
@@ -454,49 +470,13 @@ def validate(target: Path, template_file: Path | None = None) -> bool:
     target = target.resolve()
     logger.info(f"Validating template configuration in: {target}")
 
-    # Check if target is a git repository
-    if not _check_git_repository(target):
+    # Hard-stop preconditions: parse the config and check structure/mode.
+    config = _load_valid_config(target, template_file)
+    if config is None:
         return False
 
-    # Check for template file first to get the language
-    exists, template_file = _check_template_file_exists(target, template_file)
-    if not exists:
-        return False
-
-    # Parse YAML file
-    success, config = _parse_yaml_file(template_file)
-    if not success or config is None:
-        return False
-
-    # Get the language from config (default to "python" for backward compatibility)
-    language = config.get("language", "python")
-    logger.info(f"Project language: {language}")
-
-    # Check for language-specific project structure
-    if not _check_project_structure(target, language):
-        return False
-
-    # Validate configuration mode (templates OR include)
-    if not _validate_configuration_mode(config):
-        return False
-
-    # Validate required fields
-    validation_passed = _validate_required_fields(config)
-
-    # Validate specific field formats
-    if not _validate_repository_format(config):
-        validation_passed = False
-
-    # Validate templates if present
-    if config.get("templates") and not _validate_templates(config):
-        validation_passed = False
-
-    # Validate include if present
-    if config.get("include") and not _validate_include_paths(config):
-        validation_passed = False
-
-    # Validate optional fields
-    _validate_optional_fields(config)
+    # Accumulate field-level validation results.
+    validation_passed = _validate_config_fields(config)
 
     # Final verdict
     logger.debug("Validation complete, determining final result")
@@ -507,3 +487,73 @@ def validate(target: Path, template_file: Path | None = None) -> bool:
         logger.error("✗ Validation failed: template.yml has errors")
         logger.error("Fix the errors above and run 'rhiza validate' again")
         return False
+
+
+def _load_valid_config(target: Path, template_file: Path | None) -> dict[str, Any] | None:
+    """Run the hard-stop preconditions and return the parsed config.
+
+    Checks (in order): git repository, template-file existence, YAML syntax,
+    language-specific project structure, and configuration mode.  Any failure
+    short-circuits to ``None``.
+
+    Args:
+        target: Resolved path to the target Git repository directory.
+        template_file: Optional explicit path to the template file.
+
+    Returns:
+        The parsed configuration dict when every precondition passes, else
+        ``None``.
+    """
+    if not _check_git_repository(target):
+        return None
+
+    # Check for template file first to get the language
+    exists, template_file = _check_template_file_exists(target, template_file)
+    if not exists:
+        return None
+
+    # Parse YAML file
+    success, config = _parse_yaml_file(template_file)
+    if not success or config is None:
+        return None
+
+    # Get the language from config (default to "python" for backward compatibility)
+    language = config.get("language", "python")
+    logger.info(f"Project language: {language}")
+
+    # Check for language-specific project structure
+    if not _check_project_structure(target, language):
+        return None
+
+    # Validate configuration mode (templates OR include)
+    if not _validate_configuration_mode(config):
+        return None
+
+    return config
+
+
+def _validate_config_fields(config: dict[str, Any]) -> bool:
+    """Run the field-level validators, accumulating a single pass/fail result.
+
+    Unlike the preconditions, these checks do not short-circuit: every field is
+    validated so that all errors surface in one run.
+
+    Args:
+        config: The parsed configuration dictionary.
+
+    Returns:
+        ``True`` when every field validates, ``False`` if any check fails.
+    """
+    validation_passed = _validate_required_fields(config)
+
+    if not _validate_repository_format(config):
+        validation_passed = False
+
+    if config.get("templates") and not _validate_templates(config):
+        validation_passed = False
+
+    if config.get("include") and not _validate_include_paths(config):
+        validation_passed = False
+
+    _validate_optional_fields(config)
+    return validation_passed

--- a/src/rhiza/models/_git/lock_io.py
+++ b/src/rhiza/models/_git/lock_io.py
@@ -12,6 +12,7 @@ import contextlib
 import dataclasses
 import os
 from pathlib import Path
+from typing import Any
 
 try:
     import fcntl
@@ -92,31 +93,66 @@ def _read_previously_tracked_files(
     """
     if lock_file is None:
         lock_file = target / ".rhiza" / "template.lock"
-    if lock_file.exists():
-        try:
-            lock = TemplateLock.from_yaml(lock_file)
-            if lock.files:
-                files = {Path(f) for f in lock.files}
-                logger.debug(f"Reading previous file list from template.lock ({len(files)} files)")
-                return files
-            # Lock exists but has no files list - try to reconstruct from the
-            # base snapshot that was already fetched during this sync run.
-            if base_snapshot is not None and base_snapshot.is_dir():
-                snapshot_files = _files_from_snapshot(base_snapshot)
-                if snapshot_files:
-                    logger.debug(f"Reconstructing previous file list from base snapshot ({len(snapshot_files)} files)")
-                    return snapshot_files
-        except Exception as e:  # noqa: BLE001  # best-effort lock read; any parse/IO error falls through to the history fallback below
-            logger.debug(f"Could not read template.lock for orphan cleanup: {e}")
 
-    history_file = target / ".rhiza" / "history"
+    from_lock = _files_from_lock(lock_file, base_snapshot)
+    if from_lock is not None:
+        return from_lock
 
-    if history_file.exists():
-        logger.debug(f"Reading existing history file: {history_file.relative_to(target)}")
-    else:
+    return _files_from_history(target / ".rhiza" / "history", target)
+
+
+def _files_from_lock(lock_file: Path, base_snapshot: Path | None) -> set[Path] | None:
+    """Return the tracked-file set recorded in *lock_file*, or ``None``.
+
+    Resolution: the lock's ``files`` field when present, otherwise the
+    *base_snapshot* directory listing when the lock predates that field.
+
+    Args:
+        lock_file: Path to the ``template.lock`` file.
+        base_snapshot: Optional template snapshot at the previously-synced SHA,
+            used to reconstruct the file list when the lock has no ``files``.
+
+    Returns:
+        The tracked-file set, or ``None`` when the lock yields no usable list
+        (missing/unreadable lock, or empty with no snapshot fallback).
+    """
+    if not lock_file.exists():
+        return None
+    try:
+        lock = TemplateLock.from_yaml(lock_file)
+    except Exception as e:  # noqa: BLE001  # best-effort lock read; any parse/IO error falls through to the history fallback
+        logger.debug(f"Could not read template.lock for orphan cleanup: {e}")
+        return None
+
+    if lock.files:
+        files = {Path(f) for f in lock.files}
+        logger.debug(f"Reading previous file list from template.lock ({len(files)} files)")
+        return files
+    # Lock exists but has no files list - try to reconstruct from the base
+    # snapshot that was already fetched during this sync run.
+    if base_snapshot is not None and base_snapshot.is_dir():
+        snapshot_files = _files_from_snapshot(base_snapshot)
+        if snapshot_files:
+            logger.debug(f"Reconstructing previous file list from base snapshot ({len(snapshot_files)} files)")
+            return snapshot_files
+    return None
+
+
+def _files_from_history(history_file: Path, target: Path) -> set[Path]:
+    """Return the tracked-file set from the legacy ``.rhiza/history`` file.
+
+    Args:
+        history_file: Path to the legacy history file.
+        target: Target repository path, used only for relative-path logging.
+
+    Returns:
+        The set of tracked file paths, or an empty set when no history exists.
+    """
+    if not history_file.exists():
         logger.debug("No previous file tracking found")
         return set()
 
+    logger.debug(f"Reading existing history file: {history_file.relative_to(target)}")
     files = set()
     with history_file.open("r", encoding="utf-8") as f:
         for line in f:
@@ -234,16 +270,29 @@ def _lock_content_unchanged(lock: TemplateLock, lock_path: Path) -> bool:
         existing = TemplateLock.from_yaml(lock_path)
     except Exception:  # noqa: BLE001  # any malformed/unreadable lock means "not equal" — a safe default
         return False
+    return _lock_identity(existing) == _lock_identity(lock)
+
+
+def _lock_identity(lock: TemplateLock) -> tuple[Any, ...]:
+    """Return the content-comparison key for *lock*, excluding ``synced_at``.
+
+    Args:
+        lock: The lock whose effective content should be summarised.
+
+    Returns:
+        A tuple of every field that participates in the content comparison, so
+        two locks are content-equal iff their identities are equal.
+    """
     return (
-        existing.sha == lock.sha
-        and existing.repo == lock.repo
-        and str(existing.host) == str(lock.host)
-        and existing.ref == lock.ref
-        and existing.include == lock.include
-        and existing.exclude == lock.exclude
-        and existing.templates == lock.templates
-        and existing.files == lock.files
-        and existing.strategy == lock.strategy
+        lock.sha,
+        lock.repo,
+        str(lock.host),
+        lock.ref,
+        lock.include,
+        lock.exclude,
+        lock.templates,
+        lock.files,
+        lock.strategy,
     )
 
 

--- a/src/rhiza/models/_git/merge.py
+++ b/src/rhiza/models/_git/merge.py
@@ -116,22 +116,14 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
         conflict_files: list[str] = []
 
         for rel_path, is_new, is_deleted in file_entries:
-            paths = _MergePaths(
-                target=target / rel_path,
-                upstream=upstream_snapshot / rel_path,
-                base=base_snapshot / rel_path,
+            is_clean, is_conflict = self._merge_one_file(
+                rel_path,
+                target,
+                base_snapshot,
+                upstream_snapshot,
+                is_new=is_new,
+                is_deleted=is_deleted,
             )
-
-            if (
-                is_new
-                or is_deleted
-                or not paths.target.exists()
-                or not (paths.base.exists() and paths.upstream.exists())
-            ):
-                self._apply_non_merge(rel_path, paths, is_new=is_new, is_deleted=is_deleted)
-                continue
-
-            is_clean, is_conflict = self._git_merge_file(rel_path, paths)
             if not is_clean:
                 all_clean = False
             if is_conflict:
@@ -146,6 +138,47 @@ class MergeMixin(RemoteOpsMixin, DiffMixin):
             )
 
         return all_clean
+
+    def _merge_one_file(
+        self,
+        rel_path: str,
+        target: Path,
+        base_snapshot: Path,
+        upstream_snapshot: Path,
+        *,
+        is_new: bool,
+        is_deleted: bool,
+    ) -> tuple[bool, bool]:
+        """Merge a single file, returning ``(is_clean, is_conflict)``.
+
+        Files that were added, deleted, are absent from the target, or lack a
+        base/upstream counterpart cannot be three-way merged and are applied
+        wholesale via :meth:`_apply_non_merge`; everything else goes through
+        ``git merge-file``.
+
+        Args:
+            rel_path: Path of the file relative to the repository root.
+            target: Path to the target repository.
+            base_snapshot: Directory containing files at the previously-synced SHA.
+            upstream_snapshot: Directory containing files at the new upstream SHA.
+            is_new: Whether the diff marks this file as newly added.
+            is_deleted: Whether the diff marks this file as deleted.
+
+        Returns:
+            ``(is_clean, is_conflict)`` — ``is_clean`` is ``False`` when the
+            merge failed, ``is_conflict`` is ``True`` when markers were written.
+        """
+        paths = _MergePaths(
+            target=target / rel_path,
+            upstream=upstream_snapshot / rel_path,
+            base=base_snapshot / rel_path,
+        )
+
+        if is_new or is_deleted or not paths.target.exists() or not (paths.base.exists() and paths.upstream.exists()):
+            self._apply_non_merge(rel_path, paths, is_new=is_new, is_deleted=is_deleted)
+            return True, False
+
+        return self._git_merge_file(rel_path, paths)
 
     def _scan_conflict_artifacts(self, target: Path) -> tuple[list[str], list[str]]:
         """Scan *target* for merge-conflict artifacts left by git.

--- a/src/rhiza/models/bundle.py
+++ b/src/rhiza/models/bundle.py
@@ -149,6 +149,87 @@ class BundleDefinition:
     notes: str = ""
 
 
+def _parse_bundle_files(raw_files: Any) -> list[BundleFileEntry]:
+    """Coerce a bundle's raw ``files`` field into a list of file entries.
+
+    Args:
+        raw_files: The raw value of the ``files`` key (list, string, or absent).
+
+    Returns:
+        Parsed file entries; an empty list when *raw_files* is neither a list
+        nor a string.
+    """
+    if isinstance(raw_files, list):
+        return [BundleFileEntry.from_config_entry(e) for e in raw_files]
+    if isinstance(raw_files, str):
+        return [BundleFileEntry.from_config_entry(e) for e in _normalize_to_list(raw_files)]
+    return []
+
+
+def _parse_bundle_definitions(bundles_config: Any) -> dict[str, BundleDefinition]:
+    """Parse the ``bundles`` mapping of a config dict into definitions.
+
+    Args:
+        bundles_config: The raw ``bundles`` value from the configuration.
+
+    Returns:
+        Mapping of bundle name to :class:`BundleDefinition`.
+
+    Raises:
+        TypeError: If *bundles_config* or any entry is not a dictionary.
+    """
+    if not isinstance(bundles_config, dict):
+        msg = "Bundles must be a dictionary"
+        raise TypeError(msg)
+
+    bundles: dict[str, BundleDefinition] = {}
+    for bundle_name, bundle_data in bundles_config.items():
+        if not isinstance(bundle_data, dict):
+            msg = f"Bundle '{bundle_name}' must be a dictionary"
+            raise TypeError(msg)
+        bundles[bundle_name] = BundleDefinition(
+            description=bundle_data.get("description", ""),
+            files=_parse_bundle_files(bundle_data.get("files")),
+            requires=_normalize_to_list(bundle_data.get("requires")),
+            recommends=_normalize_to_list(bundle_data.get("recommends")),
+            standalone=bundle_data.get("standalone", True),
+            required=bool(bundle_data.get("required", False)),
+            notes=bundle_data.get("notes") or "",
+        )
+    return bundles
+
+
+def _parse_profile_definitions(profiles_config: Any) -> dict[str, ProfileDefinition]:
+    """Parse the ``profiles`` mapping of a config dict into definitions.
+
+    Args:
+        profiles_config: The raw ``profiles`` value from the configuration
+            (``None`` is treated as an empty mapping).
+
+    Returns:
+        Mapping of profile name to :class:`ProfileDefinition`.
+
+    Raises:
+        TypeError: If *profiles_config* or any entry is not a dictionary.
+    """
+    if profiles_config is None:
+        profiles_config = {}
+    elif not isinstance(profiles_config, dict):
+        msg = "Profiles must be a dictionary"
+        raise TypeError(msg)
+
+    profiles: dict[str, ProfileDefinition] = {}
+    for profile_name, profile_data in profiles_config.items():
+        if not isinstance(profile_data, dict):
+            msg = f"Profile '{profile_name}' must be a dictionary"
+            raise TypeError(msg)
+        profiles[profile_name] = ProfileDefinition(
+            description=profile_data.get("description", ""),
+            bundles=_normalize_to_list(profile_data.get("bundles")),
+        )
+    return profiles
+
+
 @dataclass(frozen=True, kw_only=True)
 class RhizaBundles(YamlSerializable):
     """Represents the structure of template-bundles.yml.
@@ -218,54 +299,8 @@ class RhizaBundles(YamlSerializable):
             TypeError: If bundle data has invalid types.
         """
         version = config.get("version")
-
-        bundles_config = config.get("bundles", {})
-        if not isinstance(bundles_config, dict):
-            msg = "Bundles must be a dictionary"
-            raise TypeError(msg)
-
-        bundles: dict[str, BundleDefinition] = {}
-        for bundle_name, bundle_data in bundles_config.items():
-            if not isinstance(bundle_data, dict):
-                msg = f"Bundle '{bundle_name}' must be a dictionary"
-                raise TypeError(msg)
-
-            raw_files = bundle_data.get("files")
-            if isinstance(raw_files, list):
-                files = [BundleFileEntry.from_config_entry(e) for e in raw_files]
-            elif isinstance(raw_files, str):
-                files = [BundleFileEntry.from_config_entry(e) for e in _normalize_to_list(raw_files)]
-            else:
-                files = []
-            requires = _normalize_to_list(bundle_data.get("requires"))
-
-            bundles[bundle_name] = BundleDefinition(
-                description=bundle_data.get("description", ""),
-                files=files,
-                requires=requires,
-                recommends=_normalize_to_list(bundle_data.get("recommends")),
-                standalone=bundle_data.get("standalone", True),
-                required=bool(bundle_data.get("required", False)),
-                notes=bundle_data.get("notes") or "",
-            )
-
-        profiles_config = config.get("profiles", {})
-        if profiles_config is None:
-            profiles_config = {}
-        elif not isinstance(profiles_config, dict):
-            msg = "Profiles must be a dictionary"
-            raise TypeError(msg)
-
-        profiles: dict[str, ProfileDefinition] = {}
-        for profile_name, profile_data in profiles_config.items():
-            if not isinstance(profile_data, dict):
-                msg = f"Profile '{profile_name}' must be a dictionary"
-                raise TypeError(msg)
-            profiles[profile_name] = ProfileDefinition(
-                description=profile_data.get("description", ""),
-                bundles=_normalize_to_list(profile_data.get("bundles")),
-            )
-
+        bundles = _parse_bundle_definitions(config.get("bundles", {}))
+        profiles = _parse_profile_definitions(config.get("profiles", {}))
         return cls(version=version, bundles=bundles, profiles=profiles)
 
     def _resolve_bundle_order(self, bundle_names: list[str], *, strict: bool) -> list[str]:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -8,6 +8,8 @@ This module tests:
 import shutil
 import subprocess  # nosec B404
 import sys
+import urllib.error
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +18,44 @@ from typer.testing import CliRunner
 
 from rhiza import __version__
 from rhiza.cli import app, version_callback
+
+
+@pytest.fixture
+def loguru_messages():
+    """Capture loguru log messages emitted during the test.
+
+    loguru writes to the stderr reference bound at import time, which neither
+    ``capsys`` nor ``capfd`` reliably intercept under ``CliRunner``.  A
+    dedicated in-process sink is the robust way to assert on log output.
+
+    Yields:
+        A list that accumulates each log record's message text.
+    """
+    from loguru import logger
+
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="TRACE", format="{message}")
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
+
+def _init_git_repo(path: Path) -> Path:
+    """Initialise a minimal git repository at *path* for CLI failure tests.
+
+    Args:
+        path: Directory to turn into a git repository (created if absent).
+
+    Returns:
+        The repository path, for convenient chaining.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    git_cmd = shutil.which("git") or "git"
+    subprocess.run([git_cmd, "init"], cwd=path, check=True)  # nosec B603
+    subprocess.run([git_cmd, "config", "user.email", "test@test.com"], cwd=path, check=True)  # nosec B603
+    subprocess.run([git_cmd, "config", "user.name", "Test"], cwd=path, check=True)  # nosec B603
+    return path
 
 
 class TestCliApp:
@@ -237,3 +277,114 @@ class TestCLIExceptionHandling:
         with patch("rhiza.cli.summarise_cmd", side_effect=RuntimeError("summarise failed")):
             result = self.runner.invoke(app, ["summarise", str(tmp_path)])
         assert result.exit_code == 1
+
+
+class TestCommandFailureMessages:
+    """Each command's realistic failure path exits non-zero with an actionable message.
+
+    Messages emitted through ``typer.echo`` land in ``result.output``; messages
+    logged via loguru are captured through the ``loguru_messages`` sink fixture
+    (CliRunner's stream capture does not see loguru output).
+    """
+
+    runner = CliRunner()
+
+    def test_sync_invalid_strategy_reports_message(self, tmp_path):
+        """Sync with an unknown --strategy exits non-zero and names the valid options."""
+        result = self.runner.invoke(app, ["sync", str(tmp_path), "--strategy", "bogus"])
+        assert result.exit_code != 0
+        assert "Unknown strategy: bogus" in result.output
+        assert "merge" in result.output
+        assert "diff" in result.output
+
+    def test_init_non_git_directory_reports_message(self, tmp_path, loguru_messages):
+        """Init on a non-git directory exits 1 and tells the user to run git init."""
+        result = self.runner.invoke(app, ["init", str(tmp_path), "--git-host", "github"])
+        assert result.exit_code == 1
+        assert any("is not a git repository" in m for m in loguru_messages)
+
+    def test_validate_invalid_template_reports_message(self, tmp_path, loguru_messages):
+        """Validate on an empty template.yml exits 1 and lists the required keys."""
+        repo = _init_git_repo(tmp_path / "repo")
+        (repo / "src").mkdir()
+        (repo / "tests").mkdir()
+        (repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        rhiza_dir = repo / ".rhiza"
+        rhiza_dir.mkdir()
+        (rhiza_dir / "template.yml").write_text("{}")
+
+        result = self.runner.invoke(app, ["validate", str(repo)])
+        assert result.exit_code == 1
+        assert any("Must specify at least one of 'profiles', 'templates', or 'include'" in m for m in loguru_messages)
+
+    def test_list_fetch_failure_reports_message(self, loguru_messages):
+        """List exits 1 and reports the failure when the GitHub API is unreachable."""
+        with patch(
+            "rhiza.commands.list_repos._fetch_repos",
+            side_effect=urllib.error.URLError("no network"),
+        ):
+            result = self.runner.invoke(app, ["list"])
+        assert result.exit_code == 1
+        assert any("Failed to fetch repositories" in m for m in loguru_messages)
+
+    def test_summarise_non_git_directory_reports_message(self, tmp_path, loguru_messages):
+        """Summarise on a non-git directory exits 1 and suggests git init."""
+        result = self.runner.invoke(app, ["summarise", str(tmp_path)])
+        assert result.exit_code == 1
+        assert any("not a git repository" in m for m in loguru_messages)
+        assert any("git init" in m for m in loguru_messages)
+
+    def test_uninstall_deletion_error_reports_message(self, tmp_path, loguru_messages):
+        """Uninstall exits 1 and reports per-file errors when a listed path cannot be removed."""
+        repo = _init_git_repo(tmp_path / "repo")
+        rhiza_dir = repo / ".rhiza"
+        rhiza_dir.mkdir()
+        # A lock listing a *directory* path: unlink() raises IsADirectoryError,
+        # which _remove_files records as an error and surfaces as a RuntimeError.
+        (repo / "tracked_dir").mkdir()
+        (rhiza_dir / "template.lock").write_text(
+            "sha: abc123\nrepo: my-org/t\nref: main\nsynced_at: '2024-11-01T10:00:00Z'\nfiles:\n  - tracked_dir\n"
+        )
+
+        result = self.runner.invoke(app, ["uninstall", str(repo), "--force"])
+        assert result.exit_code == 1
+        assert any("Failed to delete" in m for m in loguru_messages)
+
+    def test_status_corrupt_lock_exits_one(self, tmp_path):
+        """Status exits 1 when template.lock is present but unparseable."""
+        rhiza_dir = tmp_path / ".rhiza"
+        rhiza_dir.mkdir()
+        (rhiza_dir / "template.lock").write_text("key: [unterminated\n")
+        result = self.runner.invoke(app, ["status", str(tmp_path)])
+        assert result.exit_code == 1
+
+    def test_status_missing_lock_reports_actionable_warning(self, tmp_path, loguru_messages):
+        """Status with no lock file guides the user to run sync (exit 0, actionable message)."""
+        result = self.runner.invoke(app, ["status", str(tmp_path)])
+        assert result.exit_code == 0
+        assert any("run `rhiza sync` first" in m for m in loguru_messages)
+
+    def test_tree_corrupt_lock_exits_one(self, tmp_path):
+        """Tree exits 1 when template.lock is present but unparseable."""
+        rhiza_dir = tmp_path / ".rhiza"
+        rhiza_dir.mkdir()
+        (rhiza_dir / "template.lock").write_text("key: [unterminated\n")
+        result = self.runner.invoke(app, ["tree", str(tmp_path)])
+        assert result.exit_code == 1
+
+    def test_tree_missing_lock_reports_actionable_warning(self, tmp_path, loguru_messages):
+        """Tree with no lock file guides the user to run sync (exit 0, actionable message)."""
+        result = self.runner.invoke(app, ["tree", str(tmp_path)])
+        assert result.exit_code == 0
+        assert any("run `rhiza sync` first" in m for m in loguru_messages)
+
+    def test_migrate_has_no_failure_exit_path(self, tmp_path):
+        """Migrate is best-effort and idempotent: it exits 0 even with nothing to migrate.
+
+        Unlike the other commands, ``rhiza migrate`` deliberately has no
+        non-zero exit path — it skips files that already exist and reports what
+        it did. This test documents that contract so a future change that adds
+        a failure exit is a conscious decision, not an accident.
+        """
+        result = self.runner.invoke(app, ["migrate", str(_init_git_repo(tmp_path / "repo"))])
+        assert result.exit_code == 0

--- a/tests/test_commands/test_summarise.py
+++ b/tests/test_commands/test_summarise.py
@@ -924,3 +924,33 @@ class TestSummariseCommand:
         summarise(git_repo, options=SummariseOptions(output_format="plain"))
 
         assert "Last sync: 2024-11-01T10:00:00Z" in capsys.readouterr().out
+
+    def test_summarise_format_plain_no_header(self, git_repo, capsys):
+        """Plain format with include_header=False omits the title/template block."""
+        git_cmd = shutil.which("git") or "git"
+
+        (git_repo / "added.txt").write_text("new file")
+        subprocess.run([git_cmd, "add", "."], cwd=git_repo, check=True)  # nosec B603
+
+        summarise(git_repo, options=SummariseOptions(output_format="plain", include_header=False))
+
+        output = capsys.readouterr().out
+        assert "Template Synchronization" not in output
+        # Change summary and files still render.
+        assert "1 added" in output
+        assert "added.txt" in output
+
+    def test_summarise_format_plain_no_footer(self, git_repo, capsys):
+        """Plain format with include_footer=False omits the sync-date footer."""
+        git_cmd = shutil.which("git") or "git"
+
+        (git_repo / "added.txt").write_text("new file")
+        subprocess.run([git_cmd, "add", "."], cwd=git_repo, check=True)  # nosec B603
+
+        summarise(git_repo, options=SummariseOptions(output_format="plain", include_footer=False))
+
+        output = capsys.readouterr().out
+        assert "Sync date:" not in output
+        assert "Last sync:" not in output
+        # Change summary still renders.
+        assert "1 added" in output


### PR DESCRIPTION
## Summary

Addresses the two quality-scorecard findings filed from #590:

- **#591 — Code complexity 9→10:** decompose every function radon ranked C (CC 11–13) into focused helpers, no behaviour change.
- **#592 — Error handling & CLI UX 9→10:** assert each command's failure-path exit code **and** the accompanying actionable message.

## #591 — Reduce C-rank complexity to CC ≤ 10

| Function (before) | CC | Refactor |
|---|----|----------|
| `commands/validate.py:validate` | 13 | split into `_load_valid_config` (hard-stop preconditions) + `_validate_config_fields` (accumulating checks) |
| `commands/validate.py:_validate_configuration_mode` | 12 | extract `_log_configuration_mode` |
| `commands/init.py:init` | 13 | extract `_bootstrap_project_structure` |
| `commands/init.py:_get_latest_tag` | 12 | extract `_parse_version_tags` |
| `models/bundle.py:from_config` | 13 | extract `_parse_bundle_definitions` / `_parse_profile_definitions` / `_parse_bundle_files` |
| `models/_git/lock_io.py:_read_previously_tracked_files` | 13 | split into `_files_from_lock` / `_files_from_history` |
| `models/_git/lock_io.py:_lock_content_unchanged` | 11 | replace 9-way `and`-chain with a `_lock_identity` tuple comparison |
| `models/_git/merge.py:_merge_file_fallback` | 11 | extract `_merge_one_file` |
| `commands/summarise/_render.py:_generate_plain_output` | 12 | extract `_plain_header` / `_plain_change_body` / `_plain_footer` |

**Done when** (from #591): `uvx radon cc src -s` reports no block above B, gates green, coverage 100% — ✅ met. Average complexity drops **4.06 → 3.80**. The new guard clauses exposed a previously untested branch (plain output with header/footer disabled), so two `test_summarise` cases were added to hold coverage at 100%.

## #592 — Assert failure-path exit codes and messages

New `TestCommandFailureMessages` drives a realistic failure per command and asserts the non-zero exit code **and** the actionable message:

| Command | Failure exercised | Message asserted |
|---|---|---|
| `sync` | invalid `--strategy` | "Unknown strategy…" (stdout) |
| `init` | non-git directory | "is not a git repository" |
| `validate` | empty `template.yml` | "Must specify at least one of 'profiles', 'templates', or 'include'" |
| `list` | GitHub API unreachable | "Failed to fetch repositories" |
| `summarise` | non-git directory | "not a git repository" / "git init" |
| `uninstall` | undeletable listed path | "Failed to delete" |
| `status` / `tree` | corrupt lock (exit 1); missing lock | "run `rhiza sync` first" |

Adds a `loguru_messages` sink fixture — `CliRunner` does not capture loguru output, so message assertions need an in-process sink. Documents that `migrate` has no non-zero exit path by design (best-effort, idempotent).

**Done when** (from #592): every command has a test asserting its non-zero exit path and message; coverage 100% — ✅ met.

## Gates

All run via bare `make <target>`:

| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` | ✅ PASS (ty + mypy strict, 37 files) |
| `make docs-coverage` | ✅ PASS (100%) |
| `make deptry` | ✅ PASS |
| `make security` | ✅ PASS |
| `make validate` | ✅ PASS |
| `make test` | ✅ PASS (668 passed, coverage 100%) |

Closes #591. Closes #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
