### PR TITLE
docs(adr): mark ADR-0006 as rejected/reversed in practice

### DIFF
--- a/docs/adr/0006-rhiza-cli-as-claude-plugin.md
+++ b/docs/adr/0006-rhiza-cli-as-claude-plugin.md
@@ -1,6 +1,35 @@
 # ADR-0006: Make `rhiza-cli` the home of the Claude Code plugin
 
-**Status:** Proposed
+**Status:** Rejected — reversed in practice (2026-07-12)
+
+> **Update (2026-07-12).** This proposal was **not** adopted; the opposite
+> direction was implemented. Rather than folding the plugin into `rhiza-cli` and
+> retiring `rhiza-config`, the two-repo split was kept and the *presentation /
+> utility* commands were moved **out** of `rhiza-cli` **into** `rhiza-config`:
+>
+> - `rhiza-cli` PR #599 (merged 2026-07-12) removed the `status`, `tree`,
+>   `uninstall`, and `validate` CLI commands. (`validate.py` stays only as an
+>   internal helper for `sync`/`init`; it is no longer a command.) The dependency
+>   `rich`, used only by the old `tree` output, was dropped.
+> - `rhiza-config` now carries those commands as standalone
+>   `scripts/{status,tree,uninstall,validate}.py` + `commands/*.md` slash
+>   commands, alongside `stats.py` and the agent commands
+>   (`/boost`, `/quality`, `/revisit`, `/stats`). It remains a separate Claude
+>   Code plugin marketplace, **not** retired.
+> - This is precisely the "port the CLI commands *into* `rhiza-config`"
+>   alternative that the Decision below rejected. The trade-off it warned about
+>   (engine logic drifting into the presentation layer, version-matching burden
+>   across two repos) is now accepted deliberately.
+>
+> What did **not** move: `sync` and `summarise` stay in `rhiza-cli` as the real
+> engine (`models/lock.py`, `models/template.py`, the `_git/` merge). The
+> upstream `jebel-quant/rhiza` `rhiza_sync.yml` still invokes them via
+> `uvx "rhiza>=…" sync` / `… summarise`, and `rhiza-config`'s `/boost` delegates
+> its mechanical sync step to `rhiza sync` rather than reimplementing it.
+>
+> The Context, Decision, and Alternatives below are retained as the historical
+> record of what was proposed. The command inventory in Context ("eight
+> commands") describes `rhiza-cli` as it stood when this ADR was written.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,7 @@ the context, the decision itself, and its consequences for future maintainers.
 
 Each ADR follows this structure:
 
-- **Status**: Proposed / Accepted / Deprecated / Superseded
+- **Status**: Proposed / Accepted / Rejected / Deprecated / Superseded
 - **Context**: What situation or problem prompted this decision?
 - **Decision**: What did we decide to do?
 - **Consequences**: What are the positive and negative results of this decision?
@@ -23,7 +23,7 @@ Each ADR follows this structure:
 | [ADR-0003](0003-lock-file-concurrency.md) | Concurrency-safe lock file I/O with fcntl and atomic rename | Accepted |
 | [ADR-0004](0004-keep-git-utils-as-single-module.md) | Keep `models/_git_utils.py` as a single module | Superseded by ADR-0005 |
 | [ADR-0005](0005-split-git-engine-into-subpackage.md) | Split the git engine into a `models/_git/` subpackage | Accepted |
-| [ADR-0006](0006-rhiza-cli-as-claude-plugin.md) | Make `rhiza-cli` the home of the Claude Code plugin | Proposed |
+| [ADR-0006](0006-rhiza-cli-as-claude-plugin.md) | Make `rhiza-cli` the home of the Claude Code plugin | Rejected (reversed in practice) |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
## Summary

ADR-0006 proposed folding the Claude Code plugin **into** `rhiza-cli` and retiring `rhiza-config`. In practice the **opposite** was implemented:

- `rhiza-cli` PR #599 removed the `status`, `tree`, `uninstall`, and `validate` commands (`validate.py` kept only as an internal helper; `rich` dropped).
- `rhiza-config` now carries those commands as standalone `scripts/{status,tree,uninstall,validate}.py` + `commands/*.md` slash commands (alongside `stats` and the agent commands), and was **not** retired.
- This is exactly the "port the CLI commands into `rhiza-config`" alternative that ADR-0006's Decision had rejected.

`sync` and `summarise` stayed in `rhiza-cli` as the engine; the upstream `jebel-quant/rhiza` `rhiza_sync.yml` still invokes them via `uvx "rhiza>=…" sync` / `… summarise`, and `rhiza-config`'s `/boost` delegates its mechanical sync step to `rhiza sync`.

## Changes

- `docs/adr/0006-…`: status `Proposed` → **`Rejected — reversed in practice (2026-07-12)`**, with a dated Update block documenting the actual outcome. Original Context/Decision/Alternatives retained as historical record.
- `docs/adr/README.md`: updated the index status and added `Rejected` to the status legend.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)