### PR TITLE
refactor: remove the legacy .rhiza/history tracking path

### DIFF
--- a/src/rhiza/commands/summarise/_gather.py
+++ b/src/rhiza/commands/summarise/_gather.py
@@ -7,7 +7,6 @@ rendering — see :mod:`rhiza.commands.summarise._render` for output formatting.
 
 import subprocess  # nosec B404
 from collections import defaultdict
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import NamedTuple
 
@@ -269,12 +268,5 @@ def get_last_sync_date(repo_path: Path, template_repo: str = "") -> str | None:
     output = run_git_command(grep_args, cwd=repo_path)
     if output:
         return output
-
-    # Fallback: try to get date from history file if it exists
-    history_file = repo_path / ".rhiza" / "history"
-    if history_file.exists():
-        # Get the file modification time
-        stat = history_file.stat()
-        return datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
 
     return None

--- a/src/rhiza/models/_git/lock_io.py
+++ b/src/rhiza/models/_git/lock_io.py
@@ -76,7 +76,6 @@ def _read_previously_tracked_files(
     1. ``template.lock.files`` when the field is present and non-empty.
     2. *base_snapshot* directory listing when provided and non-empty (used as a
        fallback for lock files that pre-date the ``files`` field).
-    3. Legacy ``.rhiza/history`` file for backward compatibility.
 
     Args:
         target: Target repository path.
@@ -95,10 +94,7 @@ def _read_previously_tracked_files(
         lock_file = target / ".rhiza" / "template.lock"
 
     from_lock = _files_from_lock(lock_file, base_snapshot)
-    if from_lock is not None:
-        return from_lock
-
-    return _files_from_history(target / ".rhiza" / "history", target)
+    return from_lock if from_lock is not None else set()
 
 
 def _files_from_lock(lock_file: Path, base_snapshot: Path | None) -> set[Path] | None:
@@ -120,7 +116,7 @@ def _files_from_lock(lock_file: Path, base_snapshot: Path | None) -> set[Path] |
         return None
     try:
         lock = TemplateLock.from_yaml(lock_file)
-    except Exception as e:  # noqa: BLE001  # best-effort lock read; any parse/IO error falls through to the history fallback
+    except Exception as e:  # noqa: BLE001  # best-effort lock read; any parse/IO error yields no tracked-file list
         logger.debug(f"Could not read template.lock for orphan cleanup: {e}")
         return None
 
@@ -136,30 +132,6 @@ def _files_from_lock(lock_file: Path, base_snapshot: Path | None) -> set[Path] |
             logger.debug(f"Reconstructing previous file list from base snapshot ({len(snapshot_files)} files)")
             return snapshot_files
     return None
-
-
-def _files_from_history(history_file: Path, target: Path) -> set[Path]:
-    """Return the tracked-file set from the legacy ``.rhiza/history`` file.
-
-    Args:
-        history_file: Path to the legacy history file.
-        target: Target repository path, used only for relative-path logging.
-
-    Returns:
-        The set of tracked file paths, or an empty set when no history exists.
-    """
-    if not history_file.exists():
-        logger.debug("No previous file tracking found")
-        return set()
-
-    logger.debug(f"Reading existing history file: {history_file.relative_to(target)}")
-    files = set()
-    with history_file.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith("#"):
-                files.add(Path(line))
-    return files
 
 
 def _delete_orphaned_file(target: Path, file_path: Path) -> None:

--- a/src/rhiza/models/_git/snapshot.py
+++ b/src/rhiza/models/_git/snapshot.py
@@ -47,7 +47,6 @@ def _excluded_set(base_dir: Path, excluded_paths: list[str]) -> set[str]:
     for f in _expand_paths(base_dir, excluded_paths):
         result.add(str(f.relative_to(base_dir)))
     result.add(".rhiza/template.yml")
-    result.add(".rhiza/history")
     return result
 
 

--- a/tests/test_commands/test_summarise.py
+++ b/tests/test_commands/test_summarise.py
@@ -315,30 +315,6 @@ class TestSummariseCommand:
         # Should indicate no changes
         assert "No changes" in output or "0 file" in output
 
-    def test_summarise_with_history_file(self, git_repo, capsys):
-        """Test summarise with .rhiza/history file for last sync date."""
-        git_cmd = shutil.which("git") or "git"
-
-        # Create .rhiza/history file
-        rhiza_dir = git_repo / ".rhiza"
-        rhiza_dir.mkdir(parents=True)
-        history_file = rhiza_dir / "history"
-        history_file.write_text("some history")
-
-        # Create and stage a file
-        test_file = git_repo / "test.txt"
-        test_file.write_text("test")
-        subprocess.run([git_cmd, "add", "."], cwd=git_repo, check=True)  # nosec B603
-
-        # Run summarise
-        summarise(git_repo)
-
-        captured = capsys.readouterr()
-        output = captured.out
-
-        # Should include last sync date
-        assert "Last sync" in output or "Sync date" in output
-
     def test_summarise_with_output_file(self, git_repo, tmp_path):
         """Test summarise writes to output file."""
         git_cmd = shutil.which("git") or "git"

--- a/tests/test_commands/test_sync.py
+++ b/tests/test_commands/test_sync.py
@@ -63,16 +63,6 @@ def _commit_all(project, git_ctx, message="add files"):
     )
 
 
-def _write_history(tmp_path, files):
-    """Write a history file listing tracked files."""
-    history_file = tmp_path / ".rhiza" / "history"
-    history_file.parent.mkdir(parents=True, exist_ok=True)
-    with history_file.open("w") as f:
-        f.write("# Rhiza Template History\n")
-        for name in files:
-            f.write(f"{name}\n")
-
-
 class TestLockFile:
     """Tests for lock-file helpers."""
 
@@ -397,57 +387,6 @@ class TestSyncCommand:
 
 class TestSyncOrphanedFiles:
     """Tests verifying that orphaned files are deleted when template.yml changes during sync."""
-
-    @patch("subprocess.run")
-    @patch("rhiza.commands.sync.shutil.rmtree")
-    @patch("rhiza.models._git.context.GitContext.clone_repository")
-    @patch("rhiza.commands.sync.tempfile.mkdtemp")
-    @patch("rhiza.models._git.context.GitContext.get_head_sha")
-    def test_merge_first_sync_deletes_orphaned_files(
-        self, mock_sha, mock_mkdtemp, mock_clone, mock_rmtree, mock_run, tmp_path
-    ):
-        """Merge strategy (first sync) removes files no longer present in the updated template."""
-        # Setup git status check mock to return clean
-        mock_result = MagicMock()
-        mock_result.stdout = ""
-        mock_run.return_value = mock_result
-
-        # Template now only includes new.txt (old.txt was removed from template.yml)
-        _setup_project(tmp_path, include=["new.txt"])
-
-        # History from a previous sync tracked both files
-        _write_history(tmp_path, ["old.txt", "new.txt"])
-
-        # Both files exist in the project
-        (tmp_path / "old.txt").write_text("old content")
-        (tmp_path / "new.txt").write_text("existing content")
-
-        mock_sha.return_value = "first111"
-
-        # Upstream clone only provides new.txt
-        clone_dir = tmp_path / "upstream_clone"
-        clone_dir.mkdir()
-        (clone_dir / "new.txt").write_text("new template content\n")
-
-        snapshot_dir = tmp_path / "upstream_snapshot"
-        snapshot_dir.mkdir()
-
-        # merge also creates base_snapshot dir
-        base_snapshot_dir = tmp_path / "base_snapshot"
-        base_snapshot_dir.mkdir()
-
-        mock_mkdtemp.side_effect = [str(clone_dir), str(snapshot_dir), str(base_snapshot_dir)]
-
-        sync(tmp_path, "main", None, "merge")
-
-        # new.txt should be present
-        assert (tmp_path / "new.txt").exists()
-        # old.txt should be deleted as it is no longer in the template
-        assert not (tmp_path / "old.txt").exists()
-
-        # template.lock should record the currently synced files
-        lock_content = TemplateLock.from_yaml(tmp_path / ".rhiza" / "template.lock")
-        assert lock_content.files == ["new.txt"]
 
 
 class TestSyncCLI:
@@ -1449,8 +1388,8 @@ class TestThreeWayMergeSyncMergeStrategy:
     """Integration tests for ``_sync_merge`` end-to-end (the merge strategy entry point).
 
     Tests the full merge pipeline from first-sync to subsequent-sync, verifying
-    that lock files, history files, and orphan cleanup all work correctly
-    alongside the 3-way merge.
+    that lock files and orphan cleanup all work correctly alongside the
+    3-way merge.
     """
 
     @pytest.fixture
@@ -1829,15 +1768,12 @@ class TestCleanOrphanedFiles:
 
         assert template_yml.exists(), ".rhiza/template.yml must never be auto-deleted"
 
-    def test_read_previously_tracked_files_legacy_history(self, tmp_path):
-        """Falls back to .rhiza/history when no template.lock files list."""
+    def test_returns_empty_when_no_lock(self, tmp_path):
+        """Returns an empty set when there is no template.lock to read."""
         rhiza_dir = tmp_path / ".rhiza"
         rhiza_dir.mkdir(parents=True)
-        (rhiza_dir / "history").write_text("Makefile\n.github/workflows/ci.yml\n# comment\n")
 
-        files = _read_previously_tracked_files(tmp_path)
-        assert Path("Makefile") in files
-        assert Path(".github/workflows/ci.yml") in files
+        assert _read_previously_tracked_files(tmp_path) == set()
 
     def test_skips_nonexistent_file(self, tmp_path):
         """When file does not exist, a debug message is logged and nothing raises."""
@@ -1859,8 +1795,9 @@ class TestCleanOrphanedFiles:
         """When all tracked files are still provided by the template, no deletions happen."""
         rhiza_dir = tmp_path / ".rhiza"
         rhiza_dir.mkdir(parents=True)
-        history_file = rhiza_dir / "history"
-        history_file.write_text("file_a.txt\nfile_b.txt\n")
+        (rhiza_dir / "template.lock").write_text(
+            "sha: abc123\nrepo: owner/repo\nfiles:\n  - file_a.txt\n  - file_b.txt\n"
+        )
 
         # All tracked files are also in template_files → no orphans
         template_files = [Path("file_a.txt"), Path("file_b.txt")]
@@ -1881,8 +1818,8 @@ class TestCleanOrphanedFiles:
         assert Path(".github/workflows/ci.yml") in files
         assert len(files) == 2
 
-    def test_falls_back_to_history_when_lock_raises(self, tmp_path):
-        """When template.lock is unreadable, falls back to history file."""
+    def test_returns_empty_when_lock_unreadable(self, tmp_path):
+        """When template.lock is unreadable, returns an empty set (no tracking info)."""
         rhiza_dir = tmp_path / ".rhiza"
         rhiza_dir.mkdir(parents=True)
 
@@ -1890,15 +1827,11 @@ class TestCleanOrphanedFiles:
         lock_file = rhiza_dir / "template.lock"
         lock_file.write_text("sha: abc\n")
 
-        # Write a history file as fallback
-        history_file = rhiza_dir / "history"
-        history_file.write_text("Makefile\n")
-
         # Force TemplateLock.from_yaml to raise
         with patch("rhiza.models._git.lock_io.TemplateLock.from_yaml", side_effect=Exception("corrupt lock")):
             files = _read_previously_tracked_files(tmp_path)
 
-        assert Path("Makefile") in files
+        assert files == set()
 
 
 class TestFilesFromSnapshot:
@@ -1964,20 +1897,19 @@ class TestReadPreviouslyTrackedFilesWithBaseSnapshot:
         assert Path("from-snapshot.txt") not in files
 
     def test_ignores_empty_base_snapshot(self, tmp_path):
-        """An empty base_snapshot does not override fallback to history."""
+        """An empty base_snapshot with a files-less lock yields an empty set."""
         rhiza_dir = tmp_path / ".rhiza"
         rhiza_dir.mkdir(parents=True)
         (rhiza_dir / "template.lock").write_text(
             "sha: abc123\nrepo: owner/repo\nhost: github\nref: main\n",
         )
-        (rhiza_dir / "history").write_text("from-history.txt\n")
 
         empty_snapshot = tmp_path / "empty_snapshot"
         empty_snapshot.mkdir()
 
         files = _read_previously_tracked_files(tmp_path, base_snapshot=empty_snapshot)
 
-        assert Path("from-history.txt") in files
+        assert files == set()
 
     def test_clean_orphaned_files_passes_base_snapshot_through(self, tmp_path):
         """_clean_orphaned_files passes base_snapshot to _read_previously_tracked_files."""

--- a/tests/test_models/test_template_model.py
+++ b/tests/test_models/test_template_model.py
@@ -525,7 +525,6 @@ class TestRhizaTemplateSnapshot:
         assert not (snapshot_dir / "skip.txt").exists()
         assert "skip.txt" in excludes
         assert ".rhiza/template.yml" in excludes
-        assert ".rhiza/history" in excludes
 
     def test_snapshot_returns_excludes_for_downstream_use(self, tmp_path):
         """_excluded_set returns the excludes set so callers can pass it to merge helpers."""


### PR DESCRIPTION
## Summary

`.rhiza/history` was the original tracked-file mechanism. Since the `template.lock` `files` field (PR #296) it has been **write-dead** — nothing produces it anymore; the code only *read* it as a backward-compat fallback for repos last synced by a pre-`files` rhiza. This removes that redundant second mechanism.

## Changes (all in the models `_git` engine + summarise)

- **`models/_git/lock_io.py`** — delete `_files_from_history()` and the step-3 history fallback in `_read_previously_tracked_files`. Resolution is now: `template.lock.files` → base-snapshot listing → empty set.
- **`models/_git/snapshot.py`** — stop reserving `.rhiza/history` in the excluded set (the file is never created).
- **`commands/summarise/_gather.py`** — drop the history-mtime fallback for the last-sync date. Lock `synced_at` (primary) and the git-log grep still stand; removed the now-unused `datetime` import.

## Behavior change

`rhiza sync` no longer reads `.rhiza/history`. Orphan cleanup now requires a `template.lock` (which every sync since PR #296 writes). The only lost capability is orphan cleanup for a repo whose last sync predates the `files` field *and* has no lock — an ancient state.

## Tests

- History-fallback unit tests → rewritten to assert the new "empty set" behavior.
- The first-sync-orphan-deletion-via-history test is removed (that scenario no longer exists); incremental orphan cleanup stays covered by the lock-based unit tests and the e2e merge tests.
- Removed the summarise history-mtime test.

## Verification

- 385 tests pass, **100% coverage**
- mypy, deptry, ruff (lint + format) clean
- all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)